### PR TITLE
Formatierung für Kapitel Reihen

### DIFF
--- a/analysis_skript.tex
+++ b/analysis_skript.tex
@@ -1055,7 +1055,7 @@ Ist \suminf[k]{a_k} konvergent \(\Rightarrow \liminf[k]{a_k} = 0\).
 \begin{proof}
 \[\begin{aligned}[t]
 &a_n = \sum_{k = m}^{n}{a_k} \\
-&\text{Da } \suminf[k]{a_k} < \infty \overset{\text{Cauchy-Kriterium}}{\Rightarrow} \forall \epsilon > 0 \sp \exists N \in \N \quad \forall n \ge N \abs{a_N} = \abs{ \sum_{k = m}^{n}{a_k}} < \epsilon \Rightarrow \liminf{a_n} = 0\\
+&\text{Da } \suminf[k]{a_k} < \infty \overset{\text{Cauchy-Kriterium}}{\Rightarrow} \forall \epsilon > 0 \spdot \exists N \in \N \spdot \forall n \ge N \spcolon \abs{a_N} = \abs{ \sum_{k = m}^{n}{a_k}} < \epsilon \Rightarrow \liminf{a_n} = 0\\
 \end{aligned}\]
 \end{proof}
 \end{subkorr}
@@ -1072,8 +1072,8 @@ Die Reihe \suminf[k]{a_k} heißt absolut konvergent, wenn die Reihe \suminf[k]{\
 Jede absolut konvergente Reihe ist auch konvergent.
 \begin{proof}
 \[\begin{aligned}[t]
-&\text{Sei }\suminf[k]{\abs{a_k}} < \infty  \overset{\text{Cauchy-Kriterium}}{\Rightarrow} \forall \epsilon > 0 \sp \exists N \in \N \sp \forall n \ge m \ge N \sp \abs{\sum_{k=m}^{n}{\abs{a_k}}} < \epsilon \\
-&\overset{\text{Dreiecksungleichung}}{\Rightarrow} \abs{\sum_{k=m}^{n}{a_k}} \le \abs{\sum_{k=m}^{n}{\abs{a_k}}} < \epsilon \sp gilt \sp \forall n \ge m \ge N \\
+&\text{Sei }\suminf[k]{\abs{a_k}} < \infty  \overset{\text{Cauchy-Kriterium}}{\Rightarrow} \forall \epsilon > 0 \spdot \exists N \in \N \spdot \forall n \ge m \ge N \spcolon \abs{\sum_{k=m}^{n}{\abs{a_k}}} < \epsilon \\
+&\overset{\text{Dreiecksungleichung}}{\Rightarrow} \abs{\sum_{k=m}^{n}{a_k}} \le \abs{\sum_{k=m}^{n}{\abs{a_k}}} < \epsilon \text{ gilt } \forall n \ge m \ge N \\
 &\overset{\text{Cauchy-Kriterium}}{\Rightarrow} \suminf[k]{a_k}\text{ ist konvergent.}
 \end{aligned}\]
 \end{proof}
@@ -1087,14 +1087,14 @@ Die Umkehrung des Satzes gilt nicht. zB kann man zeigen, dass die Reihe \(\sumin
 \[\begin{aligned}[t]
 &\text{Sei } \suminf[k]{b_k} \text{ konvergent mit } b_k \ge 0 , \forall k \ge N_0 \\
 &\text{Sei } (a_k)_{k=0}^{\infty} \text{ eine Folge mit } \abs{a_k} \le b_k , \forall k \ge N_0 \\
-&\Rightarrow \suminf[k]{a_k} \text{ ist absolut konvergent}
+&\Rightarrow \suminf[k]{a_k} \text{ ist absolut konvergent.}
 \end{aligned}\]
 
 \begin{proof}
 \[\begin{aligned}[t]
 &\text{Sei } \suminf[k]{b_k} < \infty \text{ und } b_k > 0 \\
-&\overset{\text{Cauchy-Kriterium}}{\Rightarrow} \forall \epsilon > 0 \sp \exists N \in \N \quad \forall n \ge m \ge N \quad \abs{\sum{k=m}{n}{b_k}} < \epsilon \\
-&\overset{\abs{a_k} \le b_k}{\Rightarrow} \abs{\sum{k=m}{n}{\abs{a_k}}} \le \abs{\sum{k=m}{n}{b_k}} < \epsilon \forall n \ge m \ge N \\
+&\overset{\text{Cauchy-Kriterium}}{\Rightarrow} \forall \epsilon > 0 \spdot \exists N \in \N \spdot \forall n \ge m \ge N \spcolon \abs{\sum{k=m}{n}{b_k}} < \epsilon \\
+&\overset{\abs{a_k} \le b_k}{\Rightarrow} \abs{\sum{k=m}{n}{\abs{a_k}}} \le \abs{\sum{k=m}{n}{b_k}} < \epsilon \text{ gilt } \forall n \ge m \ge N \\
 &\overset{\text{Cauchy-Kriterium}}{\Rightarrow} \suminf[k]{\abs{a_k}} \text{ ist konvergent} \\
 &\Rightarrow \suminf[k]{a_k}\text{ ist absolut konvergent.}
 \end{aligned}\]
@@ -1105,7 +1105,7 @@ Die Umkehrung des Satzes gilt nicht. zB kann man zeigen, dass die Reihe \(\sumin
 \[\begin{aligned}[t]
 &\text{Sei } \suminf[k]{b_k} \text{ divergent mit } b_k \ge 0 , \forall k \ge N_0 \\
 &\text{Sei } (a_k)_{k=0}^{\infty} \text{eine Folge mit } \abs{a_k} \ge b_k , \forall k \ge N_0 \\
-&\Rightarrow \suminf[k]{a_k} \text{ ist auch divergent}
+&\Rightarrow \suminf[k]{a_k} \text{ ist auch divergent.}
 \end{aligned}\]
 
 \begin{proof}
@@ -1114,55 +1114,76 @@ Wäre \(\suminf[k]{a_k}\) konvergent, dann wäre nach dem Majoranten-Kriterium \
 \end{subkorr}
 
 \begin{subsatz}[Quotienten-Kriterium]
-Sei \suminf{a_n} eine Reihe mit \(a_n \ne 0 , \forall n \ge n_0\) \\
-Existiert eine reelle Zahl \(q \text{ mit } 0 < q < 1 \text{ ,so dass } \abs{\frac{a_{n+1}}{a_n}} \le q < 1 , \forall n \ge n_0 \\
-\Rightarrow \suminf{a_n}\) ist absolut konvergent.
+\[\begin{aligned}[t]
+&\text{Sei } \suminf{a_n} \text{ eine Reihe mit } a_n \ne 0 , \forall n \ge n_0 \\
+&\text{Existiert eine reelle Zahl } q \text{ mit } 0 < q < 1 \text{ ,so dass } \abs{\frac{a_{n+1}}{a_n}} \le q < 1 , \forall n \ge n_0 \\
+&\Rightarrow \suminf{a_n} \text{ist absolut konvergent.}
+\end{aligned}\]
+
 \begin{proof}
-\begin{math}
-\text{Sei } \abs{\frac{a_{n+1}}{a_n}} \le q < 1  \forall n \ge 0 \text{(o.B.d.A.)} \Rightarrow \abs{a_{n+1}} \le q \abs{a_n} \Rightarrow \abs{a_n} \le q\abs{a_{n-1}} \le q^2 \abs{a_{n-2}} \le ... \le q^n \abs{a_0}.
-\text{Also }\abs{a_n} \le q^n \abs{a_0}, da \suminf{\abs{a_n}} \le \suminf{q^n \abs{a_0}} = \abs{a_0} \suminf{q^n} = \abs{a_0} \frac{1}{1-q} \text{, denn } 0 < q < 1\text{, geometrische Reihe.}
-\Rightarrow \text{ aus dem Majoranten-Kriterium folgt \suminf{a_n} ist absolut konvergent.}
-\end{math}
+\[\begin{aligned}[t]
+&\text{Sei } \abs{\frac{a_{n+1}}{a_n}} \le q < 1 \quad \forall n \ge 0 \text{(o.B.d.A.)} \\
+&\Rightarrow \abs{a_{n+1}} \le q \abs{a_n} \Rightarrow \abs{a_n} \le q\abs{a_{n-1}} \le q^2 \abs{a_{n-2}} \le ... \le q^n \abs{a_0} \\
+&\text{Also } \abs{a_n} \le q^n \abs{a_0} \text{ , da } \suminf{\abs{a_n}} \le \suminf{q^n \abs{a_0}} = \abs{a_0} \suminf{q^n} = \abs{a_0} \frac{1}{1-q} \text{, denn } 0 < q < 1\text{, geometrische Reihe.} \\
+&\overset{\text{Majoranten-Kriterium}}{\Rightarrow} \suminf{a_n} \text{ ist absolut konvergent.}
+\end{aligned}\]
 \end{proof}
 \end{subsatz}
 
 \begin{subkorr}[einfaches Quotienten-Kriterium]
-Sei \(a_n \ne 0 \sp \fa n > n_0\) und existiert \(\liminf{\abs{\frac{a_n+1}{a_n}}}\text{ und ist }\liminf{\abs{\frac{a_n+1}{a_n}}} < 1
-\Rightarrow \suminf{a_n}\) ist absolut konvergent.
+\[\begin{aligned}[t]
+&\text{Sei } a_n \ne 0 \sp \fa n > n_0 \text{ und existiert } \liminf{\abs{\frac{a_n+1}{a_n}}} \text{ und ist } \liminf{\abs{\frac{a_n+1}{a_n}}} < 1 \\
+&\Rightarrow \suminf{a_n} \text{ ist absolut konvergent.}
+\end{aligned}\]
+
 \begin{proof}
-\begin{math}
-\text{Sei } \liminf{\abs{\frac{a_n+1}{a_n}}} = \alpha < 1 \\
-\text{Sei } \epsilon = \frac{1 - \alpha}{2} > 0 \Rightarrow \exists N \sp \forall n \ge N \quad \abs{\abs{\frac{a_{n+1}}{a_n}} - \alpha} < \epsilon  = \frac{1-\alpha}{2}
-\Rightarrow \abs{\frac{a_(n+1)}{a_n}} < \frac{1-\alpha}{2} + \alpha = \frac{1+\alpha}{2} \overset{<}{\text{da } \alpha < 1} 1+\frac{1}{2} = 1
-\text{Sei } q = \frac{1 + \alpha}{2} < 1 und \abs{\frac{a_(n+1)}{a_n}} < q < 1
-\end{math}
-Nach dem Quotienten-Kriterium ist \suminf{a_n} absolut konvergent
+\[\begin{aligned}[t]
+&\text{Sei } \liminf{\abs{\frac{a_n+1}{a_n}}} = \alpha < 1 \\
+&\text{Sei } \epsilon = \frac{1 - \alpha}{2} > 0 \\
+&\Rightarrow \exists N \spdot \forall n \ge N \spcolon \abs{\abs{\frac{a_{n+1}}{a_n}} - \alpha} < \epsilon  = \frac{1-\alpha}{2} \\
+&\Rightarrow \abs{\frac{a_{n+1}}{a_n}} < \frac{1-\alpha}{2} + \alpha = \frac{1+\alpha}{2} \overset{\text{da } \alpha < 1}{<} \frac{1+1}{2} = 1 \\
+&\text{Setze } q = \frac{1 + \alpha}{2} < 1 \text{ und } \abs{\frac{a_{n+1}}{a_n}} < q < 1 \\
+&\overset{\text{Quotienten-Kriterium}}{\Rightarrow}\suminf{a_n} \text{ ist absolut konvergent.}
+\end{aligned}\]
 \end{proof}
 \end{subkorr}
 
 \begin{subbsp}
 \begin{enumerate}
-\item \(\suminf{\frac{1}{n^k}} < \infty \qquad \forall k \ge 2 \)
-[Bemerkung: Die Konvergenz gilt auch \(\fa k \in \R, k > 1\) ohne Beweis]
+\item % TODO 1. is not properly aligned
+\[\begin{aligned}[t]
+&\suminf{\frac{1}{n^k}} < \infty \qquad \forall k \ge 2 \\
+&\text{[Bemerkung: Die Konvergenz gilt auch \(\fa k \in \R, k > 1\) ohne Beweis]}
+\end{aligned}\]
+
 \begin{proof}
-\begin{math}
-\frac{1}{n^k} \le \frac{1}{n^2} \qquad \forall k \ge 2 \text{ und }\\
-\frac{1}{n^2} \le \frac{2}{n(n+1)} \text{, denn }\Leftrightarrow 2n^2 \ge n(n+1) \Leftrightarrow n^2 \ge n \Leftrightarrow n \ge 1 \\
-\Rightarrow \frac{1}{n^k} \le \frac{2}{n(n+1)} \forall k \ge 2 \text{ und } \\
-\suminf{\frac{2}{n(n+1)}} = 2 \suminf{\frac{1}{n(n+1)}} = 2 * 1 = 2 \overset{\Rightarrow}{Majoranten-Kriterium} \suminf{\text{1}{n^k}} < \infty \forall k \ge 2
-\end{math}
-Frage: Wie sind die Werte der Reihe \(\suminf{1/n^k} \text{ für } k \ge 2 \)
-Euler: \(\suminf{\frac{1}{n^2}} = \frac{\pi^2}{6} \text{, } \suminf{\frac{1}{n^4}} = \frac{\pi^4}{90} \text{, \dots , } \suminf{\frac{1}{n^{2k}}} = C_k \pi^{2k}\)
-Aber: \(\suminf{\frac{1}{n^3}} \in \R \setminus \Q \text{, } \suminf{\frac{1}{n^5}} = ? \text{, \dots , } \suminf{\frac{1}{n^{2k+1}}} = ?\)
+\[\begin{aligned}[t]
+&\frac{1}{n^k} \le \frac{1}{n^2} \quad \forall k \ge 2 \\
+&\text{ und } \frac{1}{n^2} \le \frac{2}{n(n+1)} \text{ , denn } 2n^2 \ge n(n+1) \Leftrightarrow n^2 \ge n \Leftrightarrow n \ge 1 \\
+&\Rightarrow \frac{1}{n^k} \le \frac{2}{n(n+1)} \quad \forall k \ge 2 \\
+&\text{ und } \suminf{\frac{2}{n(n+1)}} = 2 \suminf{\frac{1}{n(n+1)}} = 2 * 1 = 2 \\
+&\overset{Majoranten-Kriterium}{\Rightarrow} \suminf{\frac{1}{n^k}} < \infty \quad \forall k \ge 2
+\end{aligned}\]
 \end{proof}
-\item Die Reihe \suminf{\frac{n^2}{2^n}} ist konvergent.
-\begin{proof}[Quotienten-Kriterium]
-\(\abs{\frac{a_{n+1}}{a_n}} = \frac{\frac{(n+1)^2}{2^{n+1}}}{\frac{n^2}{2^n}} = \frac{2^n(n+1)^2}{2^{n+1}n^2} = \frac{1}{2} * \left(\frac{n+1}{n}\right)^2 = \frac{1}{2} \left(\frac{1}{1+\frac{1}{n}}\right)^2 \longrightarrow \frac{1}{2} < 1\)
+Frage: Wie sind die Werte der Reihe \(\suminf{\frac{1}{n^k}} \text{ für } k \ge 2 \) ? \\
+Euler: \(\suminf{\frac{1}{n^2}} = \frac{\pi^2}{6} \text{ , } \suminf{\frac{1}{n^4}} = \frac{\pi^4}{90} \text{ , \dots , } \suminf{\frac{1}{n^{2k}}} = C_k \pi^{2k}\) \\
+Aber: \(\suminf{\frac{1}{n^3}} \in \R \setminus \Q \text{ , } \suminf{\frac{1}{n^5}} = \text{? } \text{, \dots , } \suminf{\frac{1}{n^{2k+1}}} = \text{? }\)
+
+\item
+\[\text{Die Reihe } \suminf{\frac{n^2}{2^n}} \text{ ist konvergent.}\]
+
+\begin{proof}[Quotienten-Kriterium:]
+\[\abs{\frac{a_{n+1}}{a_n}} = \frac{\frac{(n+1)^2}{2^{n+1}}}{\frac{n^2}{2^n}} = \frac{2^n(n+1)^2}{2^{n+1}n^2} = \frac{1}{2} * \left(\frac{n+1}{n}\right)^2 = \frac{1}{2} \left(\frac{1}{1+\frac{1}{n}}\right)^2 \longrightarrow \frac{1}{2} < 1\]
 \end{proof}
-\item Die Exponentialfunktion Die Reihe $\suminf[k]{\frac{x^k}{k!}}$ ist für jedes $x \in \R$ absolut konvergent
-\begin{proof}[Quotienten-Kriterium]
-\(\abs{\frac{a_{k+1}}{a_k}} = \abs{\frac{\frac{x^{k+1}}{(k+1)!}}{\frac{x^k}{k!}}} = \frac{\abs{x^{k+1}} * k!}{\abs{x^k} * (k+1)!} = \frac{\abs{x}}{k+1} \overset{\longrightarrow}{k \to \infty} 0 \sp \forall x \in \R\\
-\Rightarrow \suminf[k]{\frac{x^k}{k!}}\) ist absolut konvergent.
+
+\item
+\[\text{Die Exponentialfunktion } \suminf[k]{\frac{x^k}{k!}} \text{ ist für jedes } x \in \R \text{ absolut konvergent.}\]
+
+\begin{proof}[Quotienten-Kriterium:]
+\[\begin{aligned}[t]
+&\abs{\frac{a_{k+1}}{a_k}} = \abs{\frac{\frac{x^{k+1}}{(k+1)!}}{\frac{x^k}{k!}}} = \frac{\abs{x^{k+1}} * k!}{\abs{x^k} * (k+1)!} = \frac{\abs{x}}{k+1} \overset{k \to \infty}{\longrightarrow} 0 \quad \forall x \in \R \\
+&\Rightarrow \suminf[k]{\frac{x^k}{k!}} \text{ ist absolut konvergent.}
+\end{aligned}\]
 \end{proof}
 \end{enumerate}
 \end{subbsp}
@@ -1171,8 +1192,10 @@ Aber: \(\suminf{\frac{1}{n^3}} \in \R \setminus \Q \text{, } \suminf{\frac{1}{n^
 \begin{enumerate}
 \item Für \(k = 1\) ist die harmonische Reihe \suminf{\frac{1}{n}} divergent.
 \item Das Quotienten-Kriterium ist hier nicht anwendbar, denn \\
-\[\suminf{\frac{1}{n}} \qquad \frac{a_{n+1}}{a_n} = \frac{1}{1 + \frac{1}{n}} \longtoinf{n} 1 \not < 1\]
-\[\suminf{\frac{1}{n^2}} \qquad \frac{a_{n+1}}{a_n} = \left(\frac{1}{1 + \frac{1}{n}}\right)^2 \longrightarrow 1 \not < 1\]
+\[\begin{aligned}[t]
+&\suminf{\frac{1}{n}} : \quad \frac{a_{n+1}}{a_n} = \frac{1}{1 + \frac{1}{n}} \longtoinf 1 \not < 1 \\
+&\suminf{\frac{1}{n^2}} : \quad \frac{a_{n+1}}{a_n} = \left(\frac{1}{1 + \frac{1}{n}}\right)^2 \longtoinf 1 \not < 1
+\end{aligned}\]
 \end{enumerate}
 \end{subbem}
 
@@ -1186,28 +1209,29 @@ Wir werden später zeigen:
 \[\e = \frac{1^n}{n!} = \liminf{\left(1 + \frac{1}{n}\right)^n} \approx 2,71828...\]
 \end{subbem}
 
-% fehlerbeheben
 \begin{subsatz}[Cauchy-Produkt von Reihe]
 Seien die Reihen \suminf{a_n} und \suminf{b_n} absolut konvergent. Für $n \in \N$ definieren wir das Cauchy-Produkt folgendermaßen:
-\[c_n = \sum_{k = 0}{n}{a_kb_{n-k}} = a_0b_n + \dots + a_nb_0\]
-Dann gilt: Die Reihe \suminf{c_n} ist absolut konvergent und $\suminf{c_n} = \left( \suminf{a_n} \right)  \left( \suminf{b_n} \right) $
-\proof[Beweisidee]
-%Beweisidee_Cauchy_Produkt.JPG
+\[c_n = \sum_{k = 0}^{n}{a_k b_{n-k}} = a_0 b_n + a_1b_{n-1} + \dots + a_n b_0\]
+Dann gilt: Die Reihe \suminf{c_n} ist absolut konvergent und \\
+\[\suminf{c_n} = \left( \suminf{a_n} \right)  \left( \suminf{b_n} \right)\]
+\proof[Beweisidee:]
+% TODO Beweisidee_Cauchy_Produkt.JPG
 \end{subsatz}
 
 \begin{subkorr}[Funktionalgleichung der Exponentialfunktion]
-Sei $exp(x) = \e^x = \suminf{\frac{x^n}{n!}}$ die Exponentialfunktion. Dann gilt:
-\[exp(x+y) = exp(x) exp(y)\]
+Sei \(exp(x) = \e^x = \suminf{\frac{x^n}{n!}}\) die Exponentialfunktion. Dann gilt:
+\[exp(x+y) = exp(x) * exp(y)\]
 \[e^{x+y} = e^x e^y\]
 \begin{proof}
-Wir bilden das Cauchy-Produkt, der absolut konvergenten Reihen $e^x$ und $ e^y$. Dafür verwenden wir den Binomischen Lehrsatz: $(a+n)^n = \sum_{k_0}^{n}{\binom{n}{k}a^kb^{n-k}} = \sum_{k_0}^{n}{\\frac{n!}{k!(n-k)!}a^kb^{n-k}}$\\
-\begin{math} \displaystyle
-\begin{aligned}
-e^x e^y &= \left(\suminf{\frac{x^n}{n!}}\right)\left(\suminf{\frac{y^n}{n!}}\right) = \suminf{\sum_{k = 0}^{n}{\frac{x^k}{k!}\frac{y^{n-k}}{(n-k)!}}} \\
-&= \suminf{\frac{1}{n!}\left(\sum_{k = 0}^{n}{\frac{n!}{k!(n-k)!}x^ky^{n-k}}\right)} = \suminf{\frac{1}{n!}\left(\sum_{k = 0}^{n}{\binom{n}{k}x^ky^{n-k}}\right)}\\
-& \overset{Binom.LS}{=} \suminf{\frac{1}{n!}(x+y)^n} = e^{x+y}
-\end{aligned}
-\end{math}
+Wir bilden das Cauchy-Produkt, der absolut konvergenten Reihen $e^x$ und $ e^y$. Dafür verwenden wir den Binomischen Lehrsatz:
+\[(a+n)^n = \sum_{k_0}^{n}{\binom{n}{k}a^kb^{n-k}} = \sum_{k_0}^{n}{\frac{n!}{k!(n-k)!}a^kb^{n-k}}\] \\
+\[\begin{aligned}
+e^x e^y &= \left(\suminf{\frac{x^n}{n!}}\right)\left(\suminf{\frac{y^n}{n!}}\right)
+= \suminf{\sum_{k = 0}^{n}{\frac{x^k}{k!}\frac{y^{n-k}}{(n-k)!}}}
+= \suminf{\frac{1}{n!}\left(\sum_{k = 0}^{n}{\frac{n!}{k!(n-k)!}x^ky^{n-k}}\right)} \\
+&= \suminf{\frac{1}{n!}\left(\sum_{k = 0}^{n}{\binom{n}{k}x^ky^{n-k}}\right)}
+\overset{Binom.LS}{=} \suminf{\frac{1}{n!}(x+y)^n} = e^{x+y}
+\end{aligned}\]
 \end{proof}
 \end{subkorr}
 

--- a/analysis_skript.tex
+++ b/analysis_skript.tex
@@ -1239,104 +1239,124 @@ e^x e^y &= \left(\suminf{\frac{x^n}{n!}}\right)\left(\suminf{\frac{y^n}{n!}}\rig
 \newpage
 \section{Stetigkeit}
 \begin{defi}
-Sei $ D \subset \R$. Eine Funktion $f : D \to \R \text{ mit } x \mapsto f(x) $. ist eine Vorschrift, die jedes $ x \in D$ genau einem WErt $f(x)$ zuordnent.
+Sei $ D \subset \R$. Eine Funktion $f : D \to \R \text{ mit } x \mapsto f(x) $ ist eine Vorschrift, die jedes $ x \in D$ genau einem Wert $f(x)$ zuordnent.
 \end{defi}
 
 \begin{bsp}
 \begin{enumerate}
-\item Für $ c \in \R \quad f : \R \to \R \text{ mit } x \mapsto f(x) = c $ heißt die konstante Funktion %+ BILD
-\item $f : \R \to \R \text{ mit } x \mapsto f(x) = x $ heißt identische Funktion % + BILD
-\item $f : \R \to \R \text{ mit } x \mapsto f(x) = \abs{x} $ heißt Betragsunktion % + BILD
+\item Für $ c \in \R \quad f : \R \to \R \text{ mit } x \mapsto f(x) = c $ heißt die konstante Funktion. %+ BILD
+\item $f : \R \to \R \text{ mit } x \mapsto f(x) = x $ heißt identische Funktion. % + BILD
+\item $f : \R \to \R \text{ mit } x \mapsto f(x) = \abs{x} $ heißt Betragsunktion. % + BILD
 \item $f : \R \to \R \text{ mit } x \mapsto f(x) = \floor{x} $ % + BILD
-\item $f : \R_+ \to \R \text{ mit } x \mapsto f(x) = \sqrt{x} $ heißt Wurzelfunktion % + BILD
-\item $f : \R \to \R \text{ mit } x \mapsto f(x) = e^x $ heißt Exponentialfunktion % + BILD
-\item $p : \R \to \R \text{ mit } x \mapsto p(x) = \sum_{k=0}{n}{a_kx^k} \text{ mit } a_k \in \R $ heißt Polynomfunktion % ev BILD
+\item $f : \R_+ \to \R \text{ mit } x \mapsto f(x) = \sqrt{x} $ heißt Wurzelfunktion. % + BILD
+\item $f : \R \to \R \text{ mit } x \mapsto f(x) = e^x $ heißt Exponentialfunktion. % + BILD
+\item $p : \R \to \R \text{ mit } x \mapsto p(x) = \sum_{k=0}{n}{a_kx^k} \text{ mit } a_k \in \R $ heißt Polynomfunktion. % ev BILD
 \end{enumerate}
 \end{bsp}
 
 \begin{defi}
-Seien $f,g : D \to \R \text{ Funktionen und } \lambda \in \R.$ Wir definieren.
-\[f+ g, f  g, \lambda f : D \to \R \]
-\[(f+g)(x) = f(x) + g(x)\]
-\[(fg)(x) = f(x) g(x)\]
-\[(\lambda f)(x) = \lambda f(x) \]
-Sei weiters $g(x) \ne 0 \forall x \in D
-\frac{f}{g} : D \to \R mit \left(\frac{f}{g}\right)(x) = \frac{f(x)}{g(x)} $\\
-Sei $ f: D \to \R, g: E \to \R, mit f(D) \subset E (f(D) = \menge{f(x)}{x \in D}
-(g  \circ  f)  :  D \to \R
-(g  \circ  f)(x) = g(f(x)) ..$
-%Grafik - D---f--->E----g--->E----g°f--> D
+Seien \(f,g : D \to \R \text{ Funktionen und } \lambda \in \R.\) Wir definieren \(f+g, fg, \lambda f : D \to \R \) mit
+\[\begin{aligned}[t]
+(f+g)(x) &= f(x) + g(x) \\
+(fg)(x) &= f(x) g(x) \\
+(\lambda f)(x) &= \lambda f(x)
+\end{aligned}\]
+
+Sei weiters \(g(x) \ne 0 \quad \forall x \in D \spcolon \frac{f}{g} : D \to \R \) mit
+\[\left(\frac{f}{g}\right)(x) = \frac{f(x)}{g(x)}\]
+
+Sei \( f: D \to \R\), \(g: E \to \R\), mit \(f(D) \subset E (f(D)) = \menge{f(x)}{x \in D}\) , \((g  \circ  f)  :  D \to \R\) mit
+\[(g \circ f)(x) = g(f(x))\]
+%TODO Grafik - D---f--->E----g--->E----g°f--> D
 \end{defi}
 
 \begin{bsp}
 \begin{enumerate}
-\item $f: \R_+ -> \R mit f(x) = \sqrt{x}
- g: \R -> \R
- f \circ g(x) = f(g(x)) = f(x^2) = \sqrt{x^2} = \abs{x}$
-\item $
- p(x) = \sum_{k=0}{n}{a_kx^k}
- q(x) = \sum_{k=0}{n}{b_kx^k}
- D:= \menge{x\in \R}{q(x) \ne 0}
- r = \frac{p}{q} : D \to \R
- r(x) = \frac{p(x)}{q(x)} heißt rationale Funktion.$
+\item Sei \(f: \R_+ \to \R\) mit \(f(x) = \sqrt{x}\) , \(g: \R \to \R\) mit \(g(x) = x^2\)
+\[f \circ g(x) = f(g(x)) = f(x^2) = \sqrt{x^2} = \abs{x}\]
+
+\item Sei \(p(x) = \sum_{k=0}{n}{a_kx^k}\) , \(q(x) = \sum_{k=0}{n}{b_kx^k}\) , \(D = \menge{x\in \R}{q(x) \ne 0}\)
+ \[r = \frac{p}{q} : D \to \R r(x) = \frac{p(x)}{q(x)} \text{ heißt rationale Funktion.}\]
 \end{enumerate}
 \end{bsp}
 
 \begin{defi}[Grenzwert einer Funktion]
-Sei $f : D \to \R$ eine Funktion, $a \in \R$ eine Zahl, sodass es mindestens eine Folge $(a_n)$ gibt mit $a_n \in D$ mit $\liminf{a_n} = a $ gibt. Man definiert \(\lim\limits_{x \to a}{ f(x)} = c\), wenn gilt: Für jede Folge $(x_n)_{n\ge0}$ mit $\liminf{x_n} = a$  gilt $\liminf{f(x_n)} = c$.\\
-$c$ heißt dann Grenzwert
+Sei $f : D \to \R$ eine Funktion und $a \in \R$ eine Zahl, sodass es mindestens eine Folge $(a_n)$ mit $a_n \in D$ und $\liminf{a_n} = a $ gibt.
+Man definiert \(\lim\limits_{x \to a}{ f(x)} = c\), wenn gilt:
+\[\text{ Für jede Folge } (x_n)_{n\ge0} \text{ mit } \liminf{x_n} = a \text{ gilt } \liminf{f(x_n)} = c\]
+$c$ ist dann der Grenzwert.
 \end{defi}
 
 \begin{defi}[Stetigkeit]
-Sei $f: D \to \R$ und $a \in D$. $f$ heißt stetig in $a$, wenn \(\lim\limits_{x \to a}{f(x)} = f(a)\). Das heißt für jede Folge $(x_n)$ mit $\liminf{x_n} = a$ ist $\liminf{f(x_n)} = f(a)$.\\
+Sei $f: D \to \R$ und $a \in D$. $f$ heißt stetig in $a$, wenn
+\[\lim\limits_{x \to a}{f(x)} = f(a)\]
+Das heißt für jede Folge $(x_n)$ mit $\liminf{x_n} = a$ ist $\liminf{f(x_n)} = f(a)$.\\
 $f$ heißt stetig in $D$, falls $f$ in jedem Punkt $a \in D$ stetig ist.
-%grafik stetigefunktionbsp.gif
-%grafik nichtstetigefunktionbsp.gif
+%TODO grafik stetigefunktionbsp.gif
+%TODO grafik nichtstetigefunktionbsp.gif
 \end{defi}
 
 \begin{bem}
-$f$ ist in $a \in D$ nicht stetig $\Leftrightarrow \exists$ eine Folge $(x_n)$ mit $\liminf{x_n} = a$ aber die Folge $(f(x_n))$ ist divergent oder $\liminf{f(x_n)} \ne f(a)$
+$f$ ist in $a \in D$ nicht stetig $\Leftrightarrow \exists$ eine Folge $(x_n)$ mit $\liminf{x_n} = a$ , aber die Folge $(f(x_n))$ ist divergent oder $\liminf{f(x_n)} \ne f(a)$
 \end{bem}
 
 \begin{prop}[Rechenregeln]
 \begin{enumerate}
-\item Seien  $f, g : D \to \R$ stetig $\lambda \in \R \Rightarrow f+ g, fg, \lambda f : D \to \R$ ist stetig.
-\item Sei $g(x) \ne 0 \forall x \in D \Rightarrow \frac{f}{g}: D \to \R$ ist stetig.
-\item Seien $f: D \to \R $ und $g:E \to \R$ stetig, mit $f(D) \subset E \Rightarrow g \circ f : D \to \R$ ist stetig.
+\item Seien  $f, g : D \to \R$ stetig und $\lambda \in \R$
+\[\Rightarrow f+g \text{ , } fg \text{ , } \lambda f : D \to \R \text{ sind stetig.}\]
+
+\item Sei \(g(x) \ne 0 \quad \forall x \in D\)
+\[\Rightarrow \frac{f}{g}: D \to \R \text{ ist stetig.}\]
+
+\item Seien \(f: D \to \R\) und \(g:E \to \R\) stetig, mit \(f(D) \subset E\)
+\[\Rightarrow g \circ f : D \to \R \text{ ist stetig.}\]
 \end{enumerate}
-\begin{proof} \begin{math}
-f+g : D \to \R. Sei x_n eine beliebige Folge mit \liminf{(x_n)} = a.
-\liminf{(f+g)(x_n)} = nach Definition = \liminf{f(x_n) + g(x_n)} = Rechenregeln f Folgen = \liminf{f(x_n)} +  \liminf{g(x_n)} = f(a) + g(a) = nach Definition = (f+g)(a). \\ analog für mal, und \lambda und division. %TODO
-\\
-g \circ f : D \to \R. Sei x_n eine beliebige Folge mit \liminf{(x_n)} = a, da f stetig ist folgt: \lim{(f(x_n)} = f(a)
-Sei y_n = f(x_n)  und b = f(a) . Da f(D) \subset E folgt \liminf{y_n} = b \in E\\
-Da g stetig in b ist, folgt \liminf{g(x_n)} = g(b) \\
-Also: \liminf{(g \circ f)(x)} = \liminf{g(f(x_n))} = \liminf{g(x_n)} = g(b) = g(f(a)) = (g \circ f)(a)
-\end{math}
+
+\begin{proof}
+\begin{enumerate}
+\item \(f+g : D \to \R\)
+\[\begin{aligned}[t]
+&\text{Sei } x_n \text{ eine beliebige Folge mit } \liminf{(x_n)} = a. \\
+&\liminf{(f+g)(x_n)} \overset{\text{Def.}}{=} \liminf{f(x_n) + g(x_n)} \overset{\text{Rechenr.  Folgen}}{=} \liminf{f(x_n)} + \liminf{g(x_n)} = f(a) + g(a) \overset{\text{Def.}}{=} (f+g)(a)
+\end{aligned}\]
+
+\item Analog für mal, \(\lambda\) und division. %TODO
+
+\item \(g \circ f : D \to \R\)
+\[\begin{aligned}[t]
+&\text{Sei } x_n \text{ eine beliebige Folge mit } \liminf{(x_n)} = a \overset{f\text{ stetig}}{\Rightarrow} \liminf{f(x_n)} = f(a) \\
+&\text{Sei } y_n = f(x_n) \text{ und } b = f(a) \overset{f(D) \subset E}{\Rightarrow}  \liminf{y_n} = b \in E \overset{g \text{ stetig in }b}{\Rightarrow} \liminf{g(x_n)} = g(b) \\
+&\liminf{(g \circ f)(x)} = \liminf{g(f(x_n))} = \liminf{g(x_n)} = g(b) = g(f(a)) = (g \circ f)(a)
+\end{aligned}\]
+\end{enumerate}
 \end{proof}
 \end{prop}
 
 \begin{satz}[$\epsilon-\delta$ Kriterium für Stetigkeit]
-Sei $f: D \to \R$ eine Funktion und $a \in D$. Dann gilt
-\[f \text{ ist stetig in }a \Leftrightarrow \forall \epsilon > 0 \exists \delta > 0 :  \forall x : \abs{x-a} < \delta \text{ gilt } \abs{f(x) - f(a)} < \epsilon\]
-%bild: deltaepsilonkrit.png // stetige Funktion
-%bild2: nichtdeltaepsilonkrit.png // Nicht stetige Funktion
+Sei $f: D \to \R$ eine Funktion und $a \in D$. Dann gilt $f$ ist stetig in $a \Leftrightarrow$
+\[\forall \epsilon > 0 \spdot \exists \delta > 0 \spdot \forall x \spcolon \abs{x-a} < \delta \Rightarrow \abs{f(x) - f(a)} < \epsilon\]
+%TODO bild: deltaepsilonkrit.png // stetige Funktion
+%TODO bild2: nichtdeltaepsilonkrit.png // Nicht stetige Funktion
+
 \begin{proof}
 \begin{enumerate}
-\item[$\Leftarrow$]	Sei $(x_n)$ eine Folge mit $\liminf{x_n} = a. \quad \zz \liminf{f(x_n)} =  f(a)$\\
-\begin{math}
-Sei \epsilon > 0 \exists \delta > 0 :  \forall x : \abs{x-a} < \delta \text{ gilt } \abs{f(x) - f(a)} < \epsilon \\
-Da \lim{x_n} = a \Rightarrow \exists N = N(\delta) : \forall n \ge N(\delta) \quad \abs{x_n - a} < \delta
-\overset{\epsilon-\delta Kriterium}{\Rightarrow} \abs{f(x) - f(a)} < \epsilon \forall n \ge N \Rightarrow \lim{f(x_n)} = f(a)
-\end{math}
-\item[$\Rightarrow$] Sei $f$ in $a$ stetig. \quad \zz ist das $\epsilon-\delta$-Kriterium.
-\begin{math}
-Angenommen: \epsilon-\delta-Kriterium gilt nicht:
- \exists \epsilon > 0 \forall \delta > 0 : \exists x \in D : \abs{x-a} < \delta \text{ und } \abs{f(x) - f(a)} \ge \epsilon.
- \Rightarrow \exists \epsilon > 0 \forall n \in \N \exists x_n \in D : \abs{x_n - a} < \frac{1}{n} = \delta \text{und} \abs{f(x_n) - f(a)} \ge \epsilon
- Betrachöte die Folge (x_n), da \abs{x_n - a} < \frac{1}{n} \Rightarrow (x_n) \longtoinf a.
- Da f stetig in a ist, folgt \liminf{f(x_n)} = f(a). \WSP zu \abs{f(x_n) -f(a)} \ge \epsilon \Rightarrow das \epsilon-\delta-Kriterium gilt.
-\end{math}
+\item[$\Leftarrow$:]	Sei $(x_n)$ eine Folge mit $\liminf{x_n} = a. \quad \zz \liminf{f(x_n)} =  f(a)$
+\[\begin{aligned}[t]
+&\text{Sei } \epsilon > 0 \text{, es gilt: } \exists \delta > 0 :  \forall x : \abs{x-a} < \delta \Rightarrow \abs{f(x) - f(a)} < \epsilon \quad (*)\\
+&\text{Weil } \lim{x_n} = a \text{ gilt: } \exists N(\delta) \spdot \forall n \ge N(\delta) \spcolon \abs{x_n - a} < \delta \\
+&\overset{(*)}{\Rightarrow} \abs{f(x) - f(a)} < \epsilon \quad \forall n \ge N \\
+&\Rightarrow \lim{f(x_n)} = f(a)
+\end{aligned}\]
+
+\item[$\Rightarrow$:] Sei $f$ in $a$ stetig. \quad \zz das $\epsilon-\delta$ Kriterium
+\[\begin{aligned}[t]
+&\text{Angenommen: $\epsilon-\delta$ Kriterium gilt nicht: } \exists \epsilon > 0 \spdot \forall \delta > 0 \spdot \exists x \in D \spcolon \abs{x-a} < \delta \sp \land \sp \abs{f(x) - f(a)} \ge \epsilon \\
+&\Rightarrow \exists \epsilon > 0 \spdot \forall n \in \N \spdot \exists x_n \in D \spcolon \abs{x_n - a} < \frac{1}{n} = \delta \text{ und } \abs{f(x_n) - f(a)} \ge \epsilon \\
+&\text{Betrachte die Folge } (x_n) \text{, da } \abs{x_n - a} < \frac{1}{n} \Rightarrow (x_n) \longtoinf a. \\
+&\text{Da $f$ stetig in $a$ ist, folgt } \liminf{f(x_n)} = f(a) \\
+&\WSP \text{ zu } \abs{f(x_n) -f(a)} \ge \epsilon \\
+&\Rightarrow \text{das $\epsilon-\delta$ Kriterium gilt.}
+\end{aligned}\]
 \end{enumerate}
 \end{proof}
 \end{satz}
@@ -1344,59 +1364,69 @@ Angenommen: \epsilon-\delta-Kriterium gilt nicht:
 \begin{bsp}
 \begin{enumerate}
 \item Die konstante Funktion $ f : \R \to \R \text{ mit } x \mapsto f(x) = 1 $ ist stetig für alle $x \in \R$
-Sei $a \in \R$ und $(x_n)$ eine Folge mit $\liminf{x_n} = a \Rightarrow \liminf{f(x)} = lim 1 = 1 = f(a)$
+\[\text{Sei } a \in \R \text{ und } (x_n) \text{ eine Folge mit } \liminf{x_n} = a \Rightarrow \liminf{f(x)} = \lim 1 = 1 = f(a)\]
 
 \item Die identische Funktion $f : \R \to \R \text{ mit } x \mapsto f(x) = x $  ist stetig für alle $x \in \R$
-Sei $a\in \R und (x_n) eine Folge mit \liminf{x_n} = a \Rightarrow \liminf{f(x_n)} = \liminf{x_n} = a = f(a)$
+\[\text{Sei } a \in \R \text { und } (x_n) \text{ eine Folge mit } \liminf{x_n} = a \Rightarrow \liminf{f(x_n)} = \liminf{x_n} = a = f(a)\]
 
-\item Jede Polynomfunktion $p : \R \to \R \text{ mit } x \mapsto p(x) = \sum_{k=0}{n}{a_kx^k} \text{ mit } a_k \in \R $ ist auf \R stetig.
+\item Jede Polynomfunktion $p : \R \to \R \text{ mit } x \mapsto p(x) = \sum_{k=0}{n}{a_kx^k} \text{ mit } a_k \in \R $ ist auf \R stetig. \\
 Dies folgt sofort aus den Rechenregeln.
 
-\item Jede rationale Funktion  $r : \R \to \R \text{ mit } x \mapsto r(x) = \frac{p(x)}{q(x)} $ ist auf ihrem Definitionsbereich stetig.
+\item Jede rationale Funktion  $r : \R \to \R \text{ mit } x \mapsto r(x) = \frac{p(x)}{q(x)} $ ist auf ihrem Definitionsbereich stetig. \\
 Dies folgt auch sofort aus den Rechenregeln.
 
 \item Die Betragsunktion $f : \R \to \R \text{ mit } x \mapsto f(x) = \abs{x} $  ist stetig auf \R
-Denn $f(x) = \begin{cases}
-x & x > 0 \qquad die identische Funktion ist stetig \\
--x & x < 0 \qquad (-1)x ist stetig (Rechenregeln) \\
-0 & x = 0 \qquad denn Sei \liminf{x_n} = 0 \Rightarrow \liminf{\abs{x_n}} = 0 = \abs{0}
-\end{cases}$
+\[\text{Denn } f(x) = \begin{cases}
+x & x > 0 \qquad \text{ die identische Funktion ist stetig} \\
+-x & x < 0 \qquad (-1)x \text{ ist stetig (Rechenregeln)} \\
+0 & x = 0 \qquad \liminf{x_n} = 0 \Rightarrow \liminf{\abs{x_n}} = 0 = \abs{0} \text{ ist stetig}
+\end{cases}\]
 
-\item Die Funktion $\abs{f} : \R \to \R $  ist stetig, wenn $ f: D \to \R $ stetig ist.
-folgt aus den Rechenregeln
+\item Die Funktion $\abs{f} : \R \to \R $  ist stetig, wenn $ f: D \to \R $ stetig ist. \\
+Folgt aus den Rechenregeln.
 
-\item Sei $f : \R \to \R \text{ mit } x \mapsto f(x) = \begin{cases} 1 & x > 0 \\ -1 & x < 0\end{cases} $ ist in $a = 0$ nicht stetig. % mit bild
-\begin{math}
-denn: Sei (x_n) =  \frac{1}{n} \Rightarrow \liminf{x_n} = \liminf{\frac{1}{n}} = 0  und \liminf{f(x_n)} = \liminf{1} = 1
-Sei (y_n) = - \frac{1}{n} \Rightarrow \liminf{y_n} = \liminf{-\frac{1}{n}} = 0  und \liminf{f(y_n)} = \liminf{-1} = -1
-\Rightarrow f ist nicht stetig in a = 0
-\end{math}
+\item Sei $f : \R \to \R \text{ mit } x \mapsto f(x) = \begin{cases} 1 & x > 0 \\ -1 & x < 0\end{cases}$ ist in $a = 0$ nicht stetig. % TODO mit bild
+\[\begin{aligned}[t]
+&\text{Sei } (x_n) = \frac{1}{n} \Rightarrow \liminf{x_n} = \liminf{\frac{1}{n}} = 0 \text{ und } \liminf{f(x_n)} = \liminf{1} = 1 \\
+&\text{ Sei } (y_n) = -\frac{1}{n} \Rightarrow \liminf{y_n} = \liminf{-\frac{1}{n}} = 0 \text{ und } \liminf{f(y_n)} = \liminf{-1} = -1 \\
+&\Rightarrow f \text{ ist nicht stetig in } a = 0
+\end{aligned}\]
 
 \item Die Exponentialfunktion $exp : \R \to \R \text{ mit } exp(x) = e^x = \suminf{\frac{x^n}{n!}} $ ist auf \R stetig.
 \begin{proof}
 \begin{enumerate}
 \item $exp$ ist in $a = 0$ stetig.
 \begin{enumerate}[label=\roman*)]
-\item Sei $\abs{x} < 1 \Rightarrow \abs{a^x - 1} \le 2 \abs{x}$.
-\begin{math}
-denn: es gilt (n+1)! \ge 2^n, da (n+1)! = \underbrace{(\underbrace{n+1}_{\ge2})\underbrace{n}_{\ge2}\dots\underbrace{2}_{=2}}_{n-mal}1 \ge 2^n \forall n \ge 1 \vphantom{\underbrace{\underbrace{2}_{2}}_{2}}\\
-Sei m \ge 1 \\
-\abs{\sum_{n=1}^{m}{\frac{x^n}{n!}}} \le \sum_{n=1}^{m}{\abs{\frac{x^n}{n!}}} = \sum_{n=1}^{m}{\frac{\abs{x}^n}{n!}}
-= \sum_{n= 0}^{m-1}{\frac{\abs{x}^{n+1}}{(n+1)!}} \le \sum_{n= 0}^{m}{\frac{\abs{x}^{n+1}}{(n+1)!}}
-= \abs{x}\sum_{n= 0}^{m}{\frac{\abs{x}^{n}}{(n+1)!}} \le \abs{x}\sum_{n= 0}^{m}{\frac{\abs{x}^{n}}{2^n}}
-= \abs{x}\sum_{n= 0}^{m}{\left(\frac{\abs{x}}{2}\right)^n}\\
-Daraus folgt \abs{a^x - 1} = \abs{\Suminf{\frac{x^n}{n!}}} = \liminf{\abs{\sum_{n=1}^{m}{\frac{x^n}{n!}}}}
-\le \liminf{\abs{x}\sum_{n=0}^{m}{\left(\frac{\abs{x}}{2}\right)^n}} = \abs{x}\suminf{\left(\underbrace{\frac{\abs{x}}{2}}_{< 1}\right)^n}
-= \abs{x}\frac{1}{1-\frac{\abs{x}}{2}} = \frac{2\abs{x}}{2-\abs{x}} \le 2\abs{x}
-\end{math}
-\item Sei $(x_n)$ eine Folge mit $\liminf{x_n} = 0 \Rightarrow \liminf{\abs{exp(x_n) -1}} \overset{i)}{\le} \liminf{2\abs{x_n}} = 0 \Rightarrow \liminf{exp(x_n)} = 1 = exp(0)$
-\end{enumerate}
+  \item Sei $\abs{x} < 1 \Rightarrow \abs{a^x - 1} \le 2 \abs{x}$
+  \[\begin{aligned}[t]
+  &\text{Denn: es gilt } (n+1)! \ge 2^n \text{ , da } (n+1)! = \underbrace{(\underbrace{n+1}_{\ge2})\underbrace{n}_{\ge2}\dots\underbrace{2}_{=2}}_{n-mal}1 \ge 2^n \forall n \ge 1 \vphantom{\underbrace{\underbrace{2}_{2}}_{2}} \\
+  &\text{Sei } m \ge 1 \text{ : } \\
+  &\abs{\sum_{n=1}^{m}{\frac{x^n}{n!}}} \le \sum_{n=1}^{m}{\abs{\frac{x^n}{n!}}} = \sum_{n=1}^{m}{\frac{\abs{x}^n}{n!}}
+  = \sum_{n= 0}^{m-1}{\frac{\abs{x}^{n+1}}{(n+1)!}} \le \sum_{n= 0}^{m}{\frac{\abs{x}^{n+1}}{(n+1)!}} \\
+  &= \abs{x}\sum_{n= 0}^{m}{\frac{\abs{x}^{n}}{(n+1)!}} \le \abs{x}\sum_{n= 0}^{m}{\frac{\abs{x}^{n}}{2^n}}
+  = \abs{x}\sum_{n= 0}^{m}{\left(\frac{\abs{x}}{2}\right)^n} \\
+  &\text{Daraus folgt: } \\
+  &\abs{a^x - 1} = \abs{\Suminf{\frac{x^n}{n!}}} = \liminf{\abs{\sum_{n=1}^{m}{\frac{x^n}{n!}}}}
+  \le \liminf{\abs{x}\sum_{n=0}^{m}{\left(\frac{\abs{x}}{2}\right)^n}} = \abs{x}\suminf{\left(\underbrace{\frac{\abs{x}}{2}}_{< 1}\right)^n} \\
+  &= \abs{x}\frac{1}{1-\frac{\abs{x}}{2}} = \frac{2\abs{x}}{2-\abs{x}} \le 2\abs{x}
+  \end{aligned}\]
+
+  \item Sei $(x_n)$ eine Folge mit $\liminf{x_n} = 0$
+  \[\begin{aligned}[t]
+  &\Rightarrow \liminf{\abs{exp(x_n) -1}} \overset{i)}{\le} \liminf{2\abs{x_n}} = 0 \\
+  &\Rightarrow \liminf{exp(x_n)} = 1 = exp(0)
+  \end{aligned}\]
+  \end{enumerate}
+
 \item $exp$ ist in $a \in \R$ stetig.
-\begin{math}
-Sei a \in \R und (x_n) eine Folge mit \liminf{x_n} = a \Rightarrow \liminf{x_n - a} = 0. Da exp stetig in 0, folgt \liminf{exp(x_n -a)} = exp(0) = 1
-\Rightarrow \liminf{exp(x_n)} = \liminf{e^{x_n}} = \liminf{e^{(x_n - a)+a}} \overset{Funktionsgleichung}{=} \liminf{e^{x_n-a} e^a} = e^a \underbrace{\liminf{e^{x_n-a}}}_{=1} = e^a 1 = e^a.
-\Rightarrow exp ist in a\in \R stetig.
-\end{math}
+\[\begin{aligned}[t]
+&\text{Sei } a \in \R \text{ und } (x_n) \text{ eine Folge mit } \liminf{x_n} = a
+\Rightarrow \liminf{x_n - a} = 0 \\
+&\overset{\text{$exp$ stetig in $0$}}{\Rightarrow} \liminf{exp(x_n -a)} = exp(0) = 1 \\
+&\Rightarrow \liminf{exp(x_n)} = \liminf{e^{x_n}} = \liminf{e^{(x_n - a)+a}} \\
+&\overset{Funktionsgleichung}{=} \liminf{e^{x_n-a} e^a} = e^a \underbrace{\liminf{e^{x_n-a}}}_{=1} = e^a 1 = e^a \\
+&\Rightarrow exp \text{ ist in } a \in \R \text{ stetig.}
+\end{aligned}\]
 \end{enumerate}
 \end{proof}
 \end{enumerate}

--- a/analysis_skript.tex
+++ b/analysis_skript.tex
@@ -1438,65 +1438,78 @@ Für jede Folge $(x_n)$ mit $\liminf{x_n} = x_0$ ist die Folge $(f(x_n))$ konver
 \end{bem}
 
 \begin{satz}[Zwischenwertsatz]
-Sei $f:[a,b] \to \R$ stetig mit $f(a) < 0$ und $f(b) > 0$. Dann gibt es ein $ x \in (a,b)$ mit f(x) = 0.
-% zwischenwertsatz.png
+Sei $f:[a,b] \to \R$ stetig mit $f(a) < 0$ und $f(b) > 0$. Dann gibt es ein $ x \in (a,b)$ mit $f(x) = 0$.
+%TODO zwischenwertsatz.png
 \begin{proof}
-Wir konstruieren durch Intervallhalbierung eine Folge, deren Grenzwert eine Nullstelle von $f$ ist.\\
+Wir konstruieren durch Intervallhalbierung eine Folge, deren Grenzwert eine Nullstelle von $f$ ist. \\
 Wir definieren induktiv zwei Folgen $(a_n)$ und $(b_n)$ mit folgenden Eigenschaften:
 \begin{itemize}
 \item $0 \le b_n - a_n \le \frac{b-a}{2^n}$
 \item $f(a_n) < 0 < f(b_n)$
 \end{itemize}
-\begin{math}
-\IA \quad a_0 = a, \quad b_n = b\\
-\IV{\text{Seien $a_n$ und $b_n$ schon konstruiert}} \\
-	\text{Definiere den Mittelpunkt }M = \frac{a_n + b_n}{2}. \text{ Ist } f(M) = 0, \text{ dann setze } x = M \\
-\IS\\
-\text{Fall 1: Ist } f(M) < 0 : a_{n+1} = M, b_{n+1} = b_n.\\
-\text{Fall 2: Ist } f(M) > 0 : a_{n+1} = b_n, b_{n+1} = M. \\
-% ev mit grafik erklären
-\text{ Nach Definition ist } f(a_{n+1}) < 0 und f(b_{n+1}) > 0.\\
-0 \le b_{n+1} - a_{n+1} \le \frac{b_n - a_n}{2}\\
-\text{Denn Fall 1: }b_{n+1} - a_{n+1} = b_n - \frac{a_n+b_n}{2} = \frac{2b_n + a_n - b_n}{2} = \frac{b_n - a_n}{2}
-\text{und Fall 2: } b_{n+1} - a_{n+1} = \frac{a_n+b_n}{2} - a_n = \frac{b_n + a_n - 2a_n}{2} = \frac{b_n - a_n}{2}
-\le \frac{b_{n-1} - a_{n-1}}{2^2} \le \dots \le \frac{b-a}{2^n+1}\\
-\end{math}
-Nach Konstruktion ist die Folge $(a_n)$ monoton wachsend und durch $b$ nach oben beschränkt. Die Folge $(b_n)$ ist monoton fallend und durch $a$ nach unten beschränkt.
-Nach dem Monotoniekriterium konvergieren die beiden Folgen $(a_n)$ und $(b_n)$. Sei $\liminf{b_n} = b_0$ und $\liminf{a_n}  = a_0$\\
-Aus $0 \le b_n - a_n \le \frac{b-a}{2}$ folgt $0 \le b_0 - a_0 \le \liminf{\frac{b-a}{2^n}} = 0$
-Dann folgt: $\liminf{a_n} = lim{b_n} = x \in (a,b)$
-Da $f(a_n) < 0 < f(b_n)$ und $f$ stetig ist, folgt $0 \le \liminf{f(b_n)} = f(x) = \liminf{f(a_n)} \le 0 \Rightarrow f(x) = 0$.
+\[\begin{aligned}[t]
+&\IA \quad a_0 = a, \quad b_n = b \\
+&\IV{\text{Seien $a_n$ und $b_n$ schon konstruiert}} \\
+&\text{Definiere den Mittelpunkt }M = \frac{a_n + b_n}{2}. \text{ Ist } f(M) = 0, \text{ dann setze } x = M .\\
+&\IS \\
+&\text{Fall 1: Ist } f(M) < 0 : a_{n+1} = M \text{ , } b_{n+1} = b_n. \\
+&\text{Fall 2: Ist } f(M) > 0 : a_{n+1} = b_n \text{ , } b_{n+1} = M.  \\
+% TODO ev mit grafik erklären
+&\text{Nach Definition ist } f(a_{n+1}) < 0 \text{ und } f(b_{n+1}) > 0. \\
+&\text{Es gilt: } 0 \le b_{n+1} - a_{n+1} \le \frac{b_n - a_n}{2} \text{ , denn} \\
+&\text{Fall 1: } b_{n+1} - a_{n+1} = b_n - \frac{a_n+b_n}{2} = \frac{2b_n + a_n - b_n}{2} = \frac{b_n - a_n}{2} \\
+&\text{Fall 2: } b_{n+1} - a_{n+1} = \frac{a_n+b_n}{2} - a_n = \frac{b_n + a_n - 2a_n}{2} = \frac{b_n - a_n}{2}
+\le \frac{b_{n-1} - a_{n-1}}{2^2} \le \dots \le \frac{b-a}{2^n+1} \\
+&\text{Nach Konstruktion ist die Folge $(a_n)$ monoton wachsend und durch $b$ nach oben beschränkt.} \\
+&\text{Die Folge $(b_n)$ ist monoton fallend und durch $a$ nach unten beschränkt.} \\
+&\text{Nach dem Monotoniekriterium konvergieren die beiden Folgen $(a_n)$ und $(b_n)$.} \\
+&\text{ Sei } \liminf{b_n} = b_0 \text{ und } \liminf{a_n}  = a_0 \\
+&0 \le b_n - a_n \le \frac{b-a}{2} \Rightarrow 0 \le b_0 - a_0 \le \liminf{\frac{b-a}{2^n}} = 0 \\
+&\Rightarrow \liminf{a_n} = \liminf{b_n} = x \in (a,b) \\
+&\text{Da } f(a_n) < 0 < f(b_n) \text{ und } f \text{ stetig ist, folgt } 0 \le \liminf{f(b_n)} = f(x) = \liminf{f(a_n)} \le 0 \Rightarrow f(x) = 0
+\end{aligned}\]
 \end{proof}
 \end{satz}
 
 \begin{defi}
-Eine Funktion $f: D \to \R$ heißt beschränkt, wenn die Menge $f(D) = \menge{f(x)}{x \in D}$ beschränkt ist.
-d.h. $\exists M \in \R$ sodass $\abs{f(x)} \le M \quad \forall x\in D$
+Eine Funktion $f: D \to \R$ heißt beschränkt, wenn die Menge $f(D) = \menge{f(x)}{x \in D}$ beschränkt ist, d.h.
+\[\forall x\in D \spdot \exists M \in \R \spcolon \abs{f(x)} \le M \quad\]
 \end{defi}
 
-\begin{satz}[vom Maximum u nd Minimum]
-Sei $[a,b]$ ein abgeschlossenes Intervall. Dann ist jede stetige Funktion $f: [a,b] \to \R$ beschränkt und nimmt ihr Maximum und Minimum an.\\
-d.h. $\exists p,q \in [a,b] \text{ mit } f(p) = sup(\menge{f(x)}{x\in[a,b]}) = sup_f und f(q) = inf(\menge{f(x)}{x\in[a,b]}) = inf_f$
+\begin{satz}[vom Maximum und Minimum]
+Sei $[a,b]$ ein abgeschlossenes Intervall. Dann ist jede stetige Funktion $f: [a,b] \to \R$ beschränkt und nimmt ihr Maximum und Minimum an, d.h.
+\[\exists p,q \in [a,b] \text{ mit } f(p) = sup(\menge{f(x)}{x\in[a,b]}) = sup_f \text{ und } f(q) = inf(\menge{f(x)}{x\in[a,b]}) = inf_f\]
+
 \begin{proof}
-Wir zeigen nur das Maximum. Denn das Minimum ist das Maximum von $-f$. \\
-Sei $M = sup(\menge{f(x)}{x\in[a,b]}) \in \R \cup \{\infty\}$.\\
-1. Ist $f$ nicht nach oben beschränkt, dann gibt es $\forall n \in \N$ ein $f(x_n)$ mit $f(x_n) \ge n \Rightarrow \liminf{f(x_n)} = \infty = M$\\
-2. Ist $f$ beschränkt $\Rightarrow M \in \R$ und $\forall n \in \N \quad \exists f(x_n)$ mit $ M-\frac{1}{n} < f(x_n) \le M \Rightarrow \liminf{f(x_n)} = M$
-Also gibt es in beiden Fällen eine Folge $(x_n)$ mit $x_n \in [a,b]$ mit $\liminf{f(x_n)} = M$.\\
-Da $x_n \in [a,b]$ ist die Folge $(x_n)$ beschränkt. Nach dem Satz von Bolzano-Weierstraß besitzt die Folge $(x_n)$ eine konvergente Teilfolge $(x_{n_k})$ mit $\liminf[k]{x_{n_k}} = p \in [a,b]$.
-Da $\liminf{f(x_n)} = M$ und jede Teilfolge eine konvergente Folge den selben Grenzwert hat folgt $\liminf[k]{f(x_{n_k})} = M$\\
-Wir wissen $\liminf[k]{x_{n_k}} = p$. Da $f$ stetig ist, folgt $\liminf[k]{f(x_{n_k})} = f(p)$. Aber $\liminf[k]{f(x_{n_k})} = M \Rightarrow M = f(p).$\\
-$\Rightarrow p$ ist Maximum der Funktion $f$.
+Wir zeigen nur das Maximum, denn das Minimum ist das Maximum von $-f$.
+\[\begin{aligned}[t]
+&\text{Sei } M = sup(\menge{f(x)}{x\in[a,b]}) \in \R \cup \{\infty\} \\
+&\text{Fall 1: Ist $f$ nicht nach oben beschränkt} \Rightarrow \forall n \in \N \spdot \exists f(x_n) \spcolon f(x_n) \ge n \Rightarrow \liminf{f(x_n)} = \infty = M \\
+&\text{Fall 2: Ist $f$ beschränkt } \Rightarrow M \in \R \text{ und } \forall n \in \N \spdot \exists f(x_n) \spcolon M-\frac{1}{n} < f(x_n) \le M \Rightarrow \liminf{f(x_n)} = M \\
+&\text{Also gibt es in beiden Fällen eine Folge $(x_n)$ mit $x_n \in [a,b]$ mit $\liminf{f(x_n)} = M$.} \\
+&\text{Da $x_n \in [a,b]$ ist die Folge $(x_n)$ beschränkt.} \\
+&\text{Nach dem Satz von Bolzano-Weierstraß besitzt die Folge $(x_n)$ eine konvergente Teilfolge $(x_{n_k})$ mit} \\
+&\liminf[k]{x_{n_k}} = p \in [a,b] \\
+&\text{Da $\liminf{f(x_n)} = M$ und jede Teilfolge eine konvergente Folge den selben Grenzwert hat, folgt} \\ &\liminf[k]{f(x_{n_k})} = M \\
+&\text{Da $f$ stetig ist, folgt} \liminf[k]{f(x_{n_k})} = f(p) \\
+&\text{Aber } \liminf[k]{f(x_{n_k})} = M \Rightarrow M = f(p) \\
+&\Rightarrow p \text{ ist Maximum der Funktion } f
+\end{aligned}\]
 \end{proof}
 \end{satz}
 
 \begin{bem}
-$f:(0,1] \to \R \text{ mit } f(x) = \frac{1}{x}$ \\ % mit grafik!
+$f:(0,1] \to \R \text{ mit } f(x) = \frac{1}{x}$ \\ % TODO mit grafik!
 $f$ ist stetig aber nicht nach oben beschränkt.
 \end{bem}
 
 \begin{defi}
-Eine Funktion $f: D \to \R$ heißt (streng) monoton wachsen wenn gilt: $\forall a,b \in D \quad a \le b \quad (a < b) \Rightarrow f(a) \le f(b) \quad (f(a) < f(b))$. Entsprechend für (streng) monoton fallend.
+Eine Funktion $f: D \to \R$ heißt (streng) monoton wachsend, wenn gilt:
+\[\begin{aligned}[t]
+&\forall a,b \in D \spcolon a \le b \Rightarrow f(a) \le f(b) \\
+&\forall a,b \in D \spcolon a < b \Rightarrow f(a) < f(b) \quad \text{(streng)}
+\end{aligned}\]
+Entsprechend für (streng) monoton fallend.
 \end{defi}
 
 \begin{satz}[von der stetigen Umkehrfunktion]

--- a/analysis_skript.tex
+++ b/analysis_skript.tex
@@ -37,9 +37,9 @@
 % für Beweise
 \def\WSP{\text{Widerspruch! }}
 \def\zz{\text{zu zeigen: }}
-\newcommand{\IA}[1][n=0]{\vspace{0.1pt}\ensuremath{\text{IA}\sp#1:}}
-\newcommand{\IV}{\vspace{0.1pt}\ensuremath{\text{IV}\sp}}
-\newcommand{\IS}[1][n \mapsto n+1]{\vspace{0.1pt}\ensuremath{\text{IS}\sp#1}}
+\newcommand{\IA}[1][n=0]{\vspace{0.1pt}\ensuremath{\text{IA:}\sp#1:}}
+\newcommand{\IV}{\vspace{0.1pt}\ensuremath{\text{IV:}\sp}}
+\newcommand{\IS}[1][n \mapsto n+1]{\vspace{0.1pt}\ensuremath{\text{IS:}\sp#1:}}
 
 %Abkürzungen logischer symbole
 \def\fa{\ensuremath{\forall}}
@@ -52,6 +52,8 @@
 
 %spacing
 \def\sp{\hspace{0,1cm}}
+\def\spdot{\sp.\sp}
+\def\spcolon{\sp:\sp}
 
 %infinite sums
 \newcommand{\suminf}[2][n]{\ensuremath{\sum_{#1= 0}^{\infty}{#2}}}
@@ -123,35 +125,35 @@
    {\satzaux[#1]\addcontentsline{toc}{subsection}{\protect\numberline{\thesubsection}Satz (#1)}}%
    \ignorespaces}
  {\endsatzaux}
- 
+
  \NewDocumentEnvironment{korr}{o}
  {\IfNoValueTF{#1}
    {\korraux\addcontentsline{toc}{subsection}{\protect\numberline{\thesubsection}Korollar}}
    {\korraux[#1]\addcontentsline{toc}{subsection}{\protect\numberline{\thesubsection}Korollar (#1)}}%
    \ignorespaces}
  {\endkorraux}
- 
+
  \NewDocumentEnvironment{prop}{o}
  {\IfNoValueTF{#1}
    {\propaux\addcontentsline{toc}{subsection}{\protect\numberline{\thesubsection}Proposition}}
    {\propaux[#1]\addcontentsline{toc}{subsection}{\protect\numberline{\thesubsection}Proposition (#1)}}%
    \ignorespaces}
  {\endpropaux}
- 
+
  \NewDocumentEnvironment{defi}{o}
  {\IfNoValueTF{#1}
    {\defiaux\addcontentsline{toc}{subsection}{\protect\numberline{\thesubsection}Definition}}
    {\defiaux[#1]\addcontentsline{toc}{subsection}{\protect\numberline{\thesubsection}Definition (#1)}}%
    \ignorespaces}
  {\enddefiaux}
- 
+
  \NewDocumentEnvironment{bsp}{o}
  {\IfNoValueTF{#1}
    {\bspaux\addcontentsline{toc}{subsection}{\protect\numberline{\thesubsection}Beispiel}}
    {\bspaux[#1]\addcontentsline{toc}{subsection}{\protect\numberline{\thesubsection}Beispiel (#1)}}%
    \ignorespaces}
  {\endbspaux}
- 
+
  \NewDocumentEnvironment{bem}{o}
  {\IfNoValueTF{#1}
    {\bemaux\addcontentsline{toc}{subsection}{\protect\numberline{\thesubsection}Bemerkung}}
@@ -165,35 +167,35 @@
    {\subsatzaux[#1]\addcontentsline{toc}{subsubsection}{\protect\numberline{\thesubsubsection}Satz (#1)}}%
    \ignorespaces}
  {\endsubsatzaux}
- 
+
  \NewDocumentEnvironment{subkorr}{o}
  {\IfNoValueTF{#1}
    {\subkorraux\addcontentsline{toc}{subsubsection}{\protect\numberline{\thesubsubsection}Korollar}}
    {\subkorraux[#1]\addcontentsline{toc}{subsubsection}{\protect\numberline{\thesubsubsection}Korollar (#1)}}%
    \ignorespaces}
  {\endsubkorraux}
- 
+
  \NewDocumentEnvironment{subprop}{o}
  {\IfNoValueTF{#1}
    {\subpropaux\addcontentsline{toc}{subsubsection}{\protect\numberline{\thesubsubsection}Proposition}}
    {\subpropaux[#1]\addcontentsline{toc}{subsubsection}{\protect\numberline{\thesubsubsection}Proposition (#1)}}%
    \ignorespaces}
  {\endsubpropaux}
- 
+
  \NewDocumentEnvironment{subdefi}{o}
  {\IfNoValueTF{#1}
    {\subdefiaux\addcontentsline{toc}{subsubsection}{\protect\numberline{\thesubsubsection}Definition}}
    {\subdefiaux[#1]\addcontentsline{toc}{subsubsection}{\protect\numberline{\thesubsubsection}Definition (#1)}}%
    \ignorespaces}
  {\endsubdefiaux}
- 
+
  \NewDocumentEnvironment{subbsp}{o}
  {\IfNoValueTF{#1}
    {\subbspaux\addcontentsline{toc}{subsubsection}{\protect\numberline{\thesubsubsection}Beispiel}}
    {\subbspaux[#1]\addcontentsline{toc}{subsubsection}{\protect\numberline{\thesubsubsection}Beispiel (#1)}}%
    \ignorespaces}
  {\endsubbspaux}
- 
+
  \NewDocumentEnvironment{subbem}{o}
  {\IfNoValueTF{#1}
    {\subbemaux\addcontentsline{toc}{subsubsection}{\protect\numberline{\thesubsubsection}Bemerkung}}
@@ -211,7 +213,7 @@
 
 \maketitle
 
-\tableofcontents 
+\tableofcontents
 \newpage
 
 \section{Reelle Zahlen}
@@ -369,7 +371,7 @@ Sei \(a > 0\).
 		\forall n \in \N \sp \exists x > 0 \text{ mit } nx > k - 1 \Rightarrow a^n \ge 1 + nx > 1 + k -1 = k
 		\end{math}
 	\item \begin{math} \displaystyle
-		\text{Sei } 0 < a < 1 \text{ und } b = \frac{1}{a} > 1 \overset{\tiny{mit (1)}}{\Rightarrow} \exists k \in \R \text{ mit }  \left(\frac{1}{a}\right)^n = b^n > k = \frac{1}{\epsilon}\\
+		\text{Sei } 0 < a < 1 \text{ und } b = \frac{1}{a} > 1 \overset{mit (1)}{\Rightarrow} \exists k \in \R \text{ mit }  \left(\frac{1}{a}\right)^n = b^n > k = \frac{1}{\epsilon}\\
 		\Rightarrow  \left(\frac{1}{a}\right)^n > \frac{1}{\epsilon} \Rightarrow  \frac{1}{a^n} > \frac{1}{\epsilon} \Rightarrow a^n < \epsilon.
 		\end{math}
 \end{enumerate}
@@ -441,7 +443,7 @@ analog für Infimum.
 \section{Komplexe Zahlen}
 Die Menge der komplexen Zahlen \C sind die Punkte der Ebene \(\R^2 = \{(a,b) : a,b \in \R\}\)
 \[(a,b) = (a, 0) + (0, b) = a (1,0) + b (0, 1)\]
-Wir setzen \(1 = (1,0), \im = (0,1) \Rightarrow z = (a, b) = a + \im b\)\\
+Wir setzen \(1 = (1,0), \im = (0,1) \Rightarrow z = (a, b) = a + \im b\)
 \begin{center}
 \begin{tikzpicture}
         \draw[step=1,help lines,black!0] (-1,-1) grid (4,4);
@@ -632,7 +634,7 @@ Ein paar Beispiele zu Folgen:
 
 \begin{subdefi}[der Konvergenz]
 Eine Folge reeller Zahlen \((a_n)_{n\in\N}\) heißt konvergent gegen \( a\in\R\) wenn
-\[\forall \epsilon > 0 \quad \exists N \in \N \quad \forall n \ge N \quad \abs{a_n - a} < \epsilon\]
+\[\forall \epsilon > 0 \spdot \exists N \in \N \spdot \forall n \ge N \spcolon \abs{a_n - a} < \epsilon\]
 \(a\) heißt der Grenzwert oder Limes der Folge \((a_n)\). Die Folge \((a_n)\) heißt divergent, wenn sie nicht konvergiert. Schreibweise: \(\lim{a_n} = a \) oder \( \lim\limits_{n \to k}{a_n} = a \). Wobei \( k \in \R\cup\{\infty, -\infty\}\)
 \end{subdefi}
 
@@ -653,26 +655,26 @@ Beispiele zur Konvergenz:
 	\item Die alternierende Folge $ \displaystyle b_n = (-1)^n$ ist divergent
 	\begin{proof}
 		Angenommen $ \displaystyle \exists a \in \R \text{ mit } \liminf{b_n} = b \\
-		\text{Wähle } \epsilon = \frac{1}{2} > 0 \Rightarrow \exists N \in \N \sp \forall n \ge N \abs{b_n - b} < \frac{1}{2} \text{. Da } b_{n+1} - b_n = 		\pm 2 \text{ ist } \forall n \ge N \\
+		\text{Wähle } \epsilon = \frac{1}{2} > 0 \Rightarrow \exists N \in \N \spdot \forall n \ge N \spcolon \abs{b_n - b} < \frac{1}{2} \text{. Da } b_{n+1} - b_n = 		\pm 2 \text{ ist } \forall n \ge N \\
 		\vphantom{\frac{1}{2}}\ 2 = \abs{b_{n+1} - b_{n}} = \abs{b_{n+1} - b - (b_n - b)} \le \abs{b_{b+1} - b} + \abs{b_n - b} < \frac{1}{2} + \frac{1}{2} = 1 \Rightarrow 2 < 1 \\
 		\WSP \Rightarrow (b_n) $ ist divergent.
 	\end{proof}
 	\item Ob die geometsiche Folge \((a^n)_{n\ge1}\) hängt davon ab, welchen Wert $a$ hat.
 	\begin{proof} Durch Fallunterscheidung
 		\begin{enumerate}
-			\item[Fall 1] \(\abs{a} < 1 \Rightarrow \liminf{a^n} = 0\) \\
-				Sei \(\epsilon > 0 \overset{\text{Archimedisches Axiom}}{\Rightarrow} \sp \exists N \in \N \quad \abs{a}^N < \epsilon \Rightarrow \forall n \ge N \quad\abs{a^n - 0} = \abs{a}^n \le \abs{a}^N < \epsilon\)
-			\item[Fall 2] \(a =  1 \Rightarrow a^n = 1 \Rightarrow \lim{a^n} = 1\)
-			\item[Fall 3] \(a = -1 \Rightarrow \) divergent weil alternierend.
-			\item[Fall 4] \(\abs{a} > 1 \quad  \forall K > 0 \sp \exists n \in \N \quad \abs{a}^n > K \text{ d.h. } (a^n)\) ist unbeschränkt.
+			\item[Fall 1:] \(\abs{a} < 1 \Rightarrow \liminf{a^n} = 0\) \\
+				Sei \(\epsilon > 0 \overset{\text{Archimedisches Axiom}}{\Rightarrow} \sp \exists N \in \N \spcolon \abs{a}^N < \epsilon \Rightarrow \forall n \ge N \spcolon \abs{a^n - 0} = \abs{a}^n \le \abs{a}^N < \epsilon\)
+			\item[Fall 2:] \(a =  1 \Rightarrow a^n = 1 \Rightarrow \lim{a^n} = 1\)
+			\item[Fall 3:] \(a = -1 \Rightarrow \) divergent weil alternierend.
+			\item[Fall 4:] \(\abs{a} > 1 \Rightarrow \forall K > 0 \spdot \exists n \in \N \spcolon \abs{a}^n > K \text{ , d.h. } (a^n)\) ist unbeschränkt.
 		\end{enumerate}
 	\end{proof}
 \end{enumerate}
 \end{subbsp}
 
 \begin{subdefi}
-Eine Folge \((a_n)\) heißt nach oben (unten) beschränkt, wenn es ein \(A \in \R\) gibt mit \[\forall n \in \N \quad a_n \le A \qquad (a_n \ge A)\]
-\((a_n)\) heißt beschränkt, wenn \((a_n)\) nach oben oder unten beschränkt ist. d.h. \[\exists K \in \R \quad \abs{a_n} \le K \lor \abs{a_n} \ge K \quad \forall n \in \N \]
+Eine Folge \((a_n)\) heißt nach oben (unten) beschränkt, wenn es ein \(A \in \R\) gibt mit \[\forall n \in \N \spcolon a_n \le A \quad \text{bzw.} \quad \forall n \in \N \spcolon a_n \ge A\]
+\((a_n)\) heißt beschränkt, wenn \((a_n)\) nach oben oder unten beschränkt ist. d.h. \[\exists K \in \R \spdot \forall n \in \N \spcolon \abs{a_n} \le K \lor \abs{a_n} \ge K \]
 \end{subdefi}
 
 \begin{subsatz}
@@ -680,7 +682,7 @@ Jede konvergente Folge \((a_n)\) ist beschränkt.
 \begin{proof}
 \begin{math} \displaystyle
 \begin{aligned}[t]
-	&\liminf{a_n} = a. \quad \text{Wähle } \epsilon = 1 > 0 \Rightarrow \exists N \in \N \quad \forall n \ge N \quad \abs{a_n - a} < 1. \\
+	&\liminf{a_n} = a. \quad \text{Wähle } \epsilon = 1 > 0 \Rightarrow \exists N \in \N \spdot \forall n \ge N \spcolon \abs{a_n - a} < 1 \\
 	&\abs{a_n} = \abs{a + (a_n - a)} \le \abs{a} + \abs{a_n- a} < \abs{a} + 1 \quad \forall n \ge N \\
 	&\text{Sei } K = max\{\abs{a_1}, \abs{a_2}, \dots, \abs{a_{n-1}}, \abs{a}+1\} \\
 	&\abs{a_n} < K \quad \forall n \ge 1 \\
@@ -704,7 +706,7 @@ Sei $(a_n)$ eine Folge. Dann gilt:
 Es reicht die erste Aussage zu zeigen, denn ist $(a_n)$ monoton fallend und nach unten beschränkt \( \Rightarrow (-a_n)\) ist monoton wachsend und nach oben beschränkt $\Rightarrow (a_n) $ ist konvergent.\\
 Sei also \((a_n) \nearrow \) und nach oben beschränkt. Mit dem Vollständigkeitsaxiom \(\Rightarrow \exists a = sup\menge{a_n}{n \in \N}\). Und sei $\epsilon > 0$
 \begin{math}
-\Rightarrow a - \epsilon \text{ ist keine obere Schranke von } \menge{a_n}{n \in \N} \Rightarrow \exists N \in \N \quad a-\epsilon < a_N \le a.\\
+\Rightarrow a - \epsilon \text{ ist keine obere Schranke von } \menge{a_n}{n \in \N} \Rightarrow \exists N \in \N \spcolon a-\epsilon < a_N \le a.\\
 \text{Da }(a_n) \nearrow \begin{aligned}[t]
 					&\Rightarrow \forall n \ge N 						&& a_N \le a_n \\
 					&\Rightarrow a-\epsilon < a_N \le a_n \le a < a+\epsilon 	&& \forall n \ge N \\
@@ -724,9 +726,9 @@ Der Grenzwert einer Folge ist eindeutig bestimmt.
 \begin{math} \displaystyle
 \text{Angenommen } \liminf{a_n} = a\text{ und }\liminf{a_n} = b\text{ und } a \ne b.\\
 \text{Sei }\epsilon = \frac{1}{2}\abs{b-a} \begin{aligned}[t]
-								&\Rightarrow \exists N_1 \sp \forall n \ge N_1 \sp \abs{a_n - a} < \epsilon \\
-								&\Rightarrow \exists N_2 \sp \forall n \ge N_2 \sp \abs{a_n - b} < \epsilon \end{aligned}\\
-\text{Sei } N = max\{N_1, N_2\} \quad \forall n \ge N \quad
+								&\Rightarrow \exists N_1 \spdot \forall n \ge N_1 \spcolon \abs{a_n - a} < \epsilon \\
+								&\Rightarrow \exists N_2 \spdot \forall n \ge N_2 \spcolon \abs{a_n - b} < \epsilon \end{aligned}\\
+\text{Sei } N = max\{N_1, N_2\} \quad \forall n \ge N \spcolon
 \begin{aligned}[t]
 \abs{b-a} 	&= \abs{(b-a_n) + (a_n - a)} \\
 		&\le \abs{b - a_n} + \abs{a_n - a} \\
@@ -752,7 +754,7 @@ Seien \((a_n)\) und \((b_n)\) zwei konvergente Folgen. Dann gilt:
 \begin{proof}
 Sei \(\liminf{a_n} = 0\text{ und } \lim{b_n} = b\).
 \begin{enumerate}
-\item Sei $\epsilon > 0 \Rightarrow \exists N_1, N_2, \in \N \quad
+\item Sei $\epsilon > 0 \Rightarrow \exists N_1, N_2, \in \N \spcolon
 \begin{aligned}[t]
 &\abs{a_n - a} < \frac{\epsilon}{2} \quad \forall n \ge N_1 \quad \text{ und } \quad  \abs{b_n - b} < \frac{\epsilon}{2} \quad \forall n \ge N_2\\
 &\Rightarrow \forall n \ge max\{N_1, N_2\}\\
@@ -767,9 +769,9 @@ Sei \(\liminf{a_n} = 0\text{ und } \lim{b_n} = b\).
 		& \abs{\lambda a_n - \lambda a} = \abs{\lambda(a_n - a)} = \abs{\lambda}\abs{a_n - a} < \lambda \frac{\epsilon}{\lambda} = \epsilon
 		\end{aligned}$
 \item Jede konvergente Folge ist beschränkt $ \displaystyle \Rightarrow \exists K \in \R \text{ mit } \abs{a_K} \le K \text{ und } \abs{b} \le K\vphantom{\frac{\epsilon}{2K}}\\
-\text{Sei } \epsilon > 0 \Rightarrow \exists N_1, N_2 \in \N \sp \abs{a_n - a} < \frac{\epsilon}{2K} \text{ und } \abs{b_n - b} < \frac{\epsilon}{2K}. \Rightarrow \vphantom{\frac{\epsilon}{2K}} \\
+\text{Sei } \epsilon > 0 \Rightarrow \exists N_1, N_2 \in \N \spcolon \abs{a_n - a} < \frac{\epsilon}{2K} \text{ und } \abs{b_n - b} < \frac{\epsilon}{2K}. \Rightarrow \vphantom{\frac{\epsilon}{2K}} \\
 \begin{aligned}[t]
-\vphantom{\frac{\epsilon}{2K}} \forall n \ge max\{N_1, N_2\} \quad \abs{a_n b_n - a b} &= \abs{a_n b_n - a_n b + a_n b + a b} = \abs{ a_n (b_n - b) + b (a_n - a)} \\
+\vphantom{\frac{\epsilon}{2K}} \forall n \ge max\{N_1, N_2\} \spcolon \abs{a_n b_n - a b} &= \abs{a_n b_n - a_n b + a_n b + a b} = \abs{ a_n (b_n - b) + b (a_n - a)} \\
 &\le \abs{ a_n (b_n - b)} + \abs{b (a_n - a)} \\
 &= \underbrace{\abs{a_n}}_{\le K} \abs{b_n - b} + \underbrace{\abs{b}}_{\le K}\abs{a_n - a} < K \frac{\epsilon}{2K} + K \frac{\epsilon}{2K} = \epsilon
 \end{aligned}$
@@ -780,7 +782,7 @@ Zeige \begin{math} \displaystyle \liminf{\frac{1}{b_n}} = \frac{1}{\liminf{b_n}}
 \abs{\frac{1}{b_n} - \frac{1}{b}} = \abs{\frac{b - b_n}{b b_n}} = \frac{1}{\abs{b_n}}\frac{1}{\abs{b}} \abs{b - b_n} < \frac{2}{\abs{b}}\frac{1}{\abs{b}}\abs{b_n - b} < \frac{2}{\abs{b}^2}\frac{\epsilon\abs{b}^2}{2} = \epsilon.
 \end{math}
 \item Sei \(a_n \le b_n \quad \forall n \ge n_0. \) \quad Angenommen \(a > b\). \quad Sei \begin{math} \displaystyle \epsilon =  \frac{a-b}{2} > 0 \\
-\Rightarrow \exists N_1, N_2 \in \N \quad \abs{a_n - a} < \epsilon \quad \forall n \ge N_1 \qquad \text{und} \qquad \abs{b_n - b} < \epsilon \quad \forall n \ge N_2 \vphantom{\frac{a-b}{2}} \\
+\Rightarrow \exists N_1, N_2 \in \N \spcolon \abs{a_n - a} < \epsilon \quad \forall n \ge N_1 \qquad \text{und} \qquad \abs{b_n - b} < \epsilon \quad \forall n \ge N_2 \vphantom{\frac{a-b}{2}} \\
 \begin{aligned}[t]
 b_n < b + \epsilon &= b + \frac{a-b}{2} = \frac{2b + a - b}{2} = \frac{b + a}{2} = \frac{2a - a + b}{2} \\
 &= a - \frac{a-b}{2} = a - \epsilon < a_n && \quad \forall n \ge max\{N_1, N_2\}
@@ -820,7 +822,7 @@ $ \displaystyle a_n = \frac{\left(\sqrt{2n} - \sqrt{n}\right)\left(\sqrt{2n} + \
 
 \begin{subdefi}
 Eine Folge \((a_n)\) heißt bestimmt divergent gegen \(\pm \infty \) wenn gilt:
-\[\forall K \in \R \quad \exists N \in \N \quad \forall n \ge N \quad  a_n \lessgtr K \]
+\[\forall K \in \R \spdot \exists N \in \N \spdot \forall n \ge N \spcolon  a_n \lessgtr K \]
 Für jedes $K$ aus \R  gibt es ein $N$ aus \N ab dem $a_n$ größer/kleiner als $K$ wird. Schreibweise: \(\liminf{a_n} = \pm \infty \)
 \end{subdefi}
 
@@ -833,7 +835,7 @@ Beispiele zu bestimmt divergenten Folgen:
 \item Die Folge \(a_n = (-1)^n\) ist divergent aber nicht bestimmt divergent.
 \item Sei \((a_n)\) bestimmt divergent und $ \displaystyle a_n \ne 0 \quad \forall n \ge n_0\text{, dann folgt }\liminf{\frac{1}{a_n}} = 0$.
 \begin{proof}Sei $ \displaystyle \liminf{a_n} = \infty \quad
-\begin{aligned}[t] &&\forall \epsilon > 0 \sp \exists N \in \N \sp \forall n \ge N \sp a_n &> \frac{1}{\epsilon} > 0 \\
+\begin{aligned}[t] &&\forall \epsilon > 0 \spdot \exists N \in \N \spdot \forall n \ge N \spcolon a_n &> \frac{1}{\epsilon} > 0 \\
 &&\Rightarrow \frac{1}{a_n} &< \epsilon \Rightarrow \abs{\frac{1}{a_n} - 0} < \epsilon  \\
 &&\text{da } a_n > 0 \Rightarrow \liminf{\frac{1}{a_n}} = 0.
 \end{aligned}$\\
@@ -848,7 +850,7 @@ Dann heißt die Folge \((a_{n_k})_{k \in \N }\) eine Teilfolge von \((a_n)_{n \i
 
 \begin{subbem}
 Ist die Folge \((a_n)\) konvergent, dann ist auch jede Teilfolge von \((a_n)\) konvergent.
-\begin{proof} Sei $(a_n)$ konvergent gegen $a$. Also $ \forall \epsilon > 0  \sp \exists N \in \N \quad \abs{a_n - a} < \epsilon \quad \forall n \ge N$. Da $(a_{n_k})$ eine Teilfolge von $(a_n)$ mit $n_0 < n_1 < n_2 < \dots < n_k < \dots$ und da $n_k$ monoton steigend ist, ist $k \le n_k$ und $n_k \ge N \quad \forall k \ge N $ daraus folgt $\abs{a_{n_k} - a} < \epsilon \quad \forall n \ge N$.
+\begin{proof} Sei $(a_n)$ konvergent gegen $a$. Also $ \forall \epsilon > 0 \spdot \exists N \in \N \spcolon \abs{a_n - a} < \epsilon \quad \forall n \ge N$. Da $(a_{n_k})$ eine Teilfolge von $(a_n)$ mit $n_0 < n_1 < n_2 < \dots < n_k < \dots$ und da $n_k$ monoton steigend ist, ist $k \le n_k$ und $n_k \ge N \quad \forall k \ge N $ daraus folgt $\abs{a_{n_k} - a} < \epsilon \quad \forall n \ge N$.
 \end{proof}
 \end{subbem}
 
@@ -886,7 +888,7 @@ Jede beschränkte Folge reeller Zahlen besitzt eine konvergente Teilfolge.
 & 2. &&\text{Da }x_k = inf(A_k) = inf\menge{a_m}{m \ge k} \Rightarrow \exists a_{k_m} \text{ mit } \abs{x_k - a_{k_m}} < \frac{\epsilon}{2}.
 \end{aligned} \\ \vphantom{\frac{\epsilon}{2}}
 &\qquad \Rightarrow \abs{a_{k_m} - z} = \abs{a_{k_m} - x_k + x_k - z} \le \abs{a_{k_m} - x_k} + \abs{x_k - z} < \frac{\epsilon}{2} + \frac{\epsilon}{2} = \epsilon  \\ \vphantom{\frac{\epsilon}{2}}
-&\qquad \text{Also } \forall \epsilon > 0 \exists N \in \N \quad \forall k \ge N \quad \exists a_{k_m} \in (a_n) \quad \abs{a_{k_m} - z} < \epsilon  \\
+&\qquad \text{Also } \forall \epsilon > 0 \spdot \exists N \in \N \spdot \forall k \ge N \spdot \exists a_{k_m} \in (a_n) \spcolon \abs{a_{k_m} - z} < \epsilon  \\
 &\qquad \text{d.h. die Teilfolge }(a_{k_m})_{m\ge 0}\text{ ist konvergent gegen } z \\
 &\text{Also }(a_{k_m})\text{ ist eine konvergente Teilfloge von der beschränkten Folge }(a_n).
 \end{aligned} \\
@@ -909,7 +911,7 @@ Der Satz von Bolzano-Weierstraß ist äquivalent zum Vollständigkeitsaxiom. And
 
 \begin{subdefi}[Cauchy-Folge]
 Eine Folge \((a_n)_{n \ge 0}\) heißt CAUCHY-Folge, wenn gilt:
-\[\forall \epsilon > 0 \quad \exists N \in \N \quad \forall n, m \ge N \quad \abs{a_n - a_m} < \epsilon\]
+\[\forall \epsilon > 0 \spdot \exists N \in \N \spdot \forall n, m \ge N \spcolon \abs{a_n - a_m} < \epsilon\]
 \end{subdefi}
 
 \begin{subsatz}
@@ -921,13 +923,13 @@ Folgende Aussagen sind äquivalent
 \begin{proof}
 \begin{math} \displaystyle
 \begin{aligned}[t]
-1) \Rightarrow 2) \quad &\text{Sei }\liminf{a_n} = a \Rightarrow \forall \epsilon > 0 \sp \exists N \sp \forall m \ge N \abs{a_n a} < \frac{\epsilon}{2} \Rightarrow \forall n, m \ge N \\
-&\abs{a_n - a_m} = \abs{a_n - a + a - a_m} \le \abs{a_n - a }  + \abs{a_m - a} <  \frac{\epsilon}{2}+ \frac{\epsilon}{2} = \epsilon \\
+1) \Rightarrow 2) \quad &\text{Sei }\liminf{a_n} = a \Rightarrow \forall \epsilon > 0 \spdot \exists N \spdot \forall m \ge N \spcolon \abs{a_n a} < \frac{\epsilon}{2} \\
+&\Rightarrow \forall n, m \ge N \spcolon \abs{a_n - a_m} = \abs{a_n - a + a - a_m} \le \abs{a_n - a }  + \abs{a_m - a} <  \frac{\epsilon}{2}+ \frac{\epsilon}{2} = \epsilon \\
 &\Rightarrow a_n \text{ ist eine Cauchy Folge}\\
 2) \Rightarrow 1) \quad &\text{Jede Cauchy Folge ist beschränkt.} \\
-& \text{Sei } \epsilon = 1 \Rightarrow \exists N \in \N \sp \forall n, m \ge N \abs{a_n - a_m} < 1 \quad \Rightarrow \abs{a_n - a_N} < 1 \\
+& \text{Sei } \epsilon = 1 \Rightarrow \exists N \in \N \spdot \forall n, m \ge N \spcolon \abs{a_n - a_m} < 1 \quad \Rightarrow \abs{a_n - a_N} < 1 \\
 &\Rightarrow \abs{a_n} = \abs{a_n - a_N + a_N} \le \abs{a_n - a_N} + \abs{a_N} < 1 + \abs{a_N} \quad \forall n  \ge N\\
-&\Rightarrow \forall n \in \N \sp \abs{a_n} \le max\{\abs{a_0},\dots,\abs{a_{N-1}},\abs{a_N} + 1\} \Rightarrow (a_n) \text{ ist beschränkt.}\\
+&\Rightarrow \forall n \in \N \spcolon \abs{a_n} \le max\{\abs{a_0},\dots,\abs{a_{N-1}},\abs{a_N} + 1\} \Rightarrow (a_n) \text{ ist beschränkt.}\\
 &\text{Nach Bolzano-Weierstraß existiert eine konvergente Teilfolge: } (a_{n_k}) \longtoinf[k] a\\
 &\zz \liminf{a_n} = a.\\
 &\text{Sei }\epsilon > 0. \text{ Wähle $m$ so groß, dass }\begin{aligned}[t]&\abs{a_m - a_n} < \frac{\epsilon}{2} \quad \forall n,m \ge N \text{ und } \\
@@ -957,12 +959,12 @@ Wir zeigen: \((x_n)\) ist konvergent und \(\liminf{x_n} = x \text{ und } x^2 = a
 &= \frac{1}{4} \left(x_n^2 - 2x_n\frac{a}{x_n} + \frac{a^2}{x_n^2} \right) = \frac{1}{4} \left(x_n - \frac{a}{x_n} \right)^2 \ge 0
 \end{aligned}
 \end{aligned} \\
-&(x_n)\text{ ist monoton fallend} \\ 
+&(x_n)\text{ ist monoton fallend} \\
 &x_n - x_{n+1} = x_n - \frac{1}{2} \left(x_n + \frac{a}{x_n}\right) =\frac{1}{2} \left(2x_n - x_n - \frac{a}{x_n}\right) = \frac{1}{2x_n\underbrace{(x_n^2 - a)}_{x_n^2 > a}} \ge 0 \\
 &\Rightarrow x_n \ge x_{n+1} \\
 &\text{Nach dem Monotonie-Kriterium ist $(x_n)$ konvergent.} \\
 &\text{Sei } x= \liminf{x_n} \quad \begin{aligned}[t] x &= \liminf{x_{n+1}} = \liminf{\frac{1}{2}\left(x_n + \frac{a}{x_n}\right)} \\
-&= \frac{1}{2}\left(\liminf{x_n} + \frac{a}{\liminf{x_n}}\right) =  \frac{1}{2}\left(x + \frac{a}{x}\right) 
+&= \frac{1}{2}\left(\liminf{x_n} + \frac{a}{\liminf{x_n}}\right) =  \frac{1}{2}\left(x + \frac{a}{x}\right)
  \end{aligned} \\
 &\Rightarrow 2x = x + \frac{a}{x} \quad \Rightarrow x = \frac{a}{x} \quad \Rightarrow x^2 = a
 \end{aligned}\\$
@@ -974,54 +976,65 @@ Die positive Lösung der Gleichung \(x^2 = a\) heißt die Quadratwurzeln von \(a
 \subsection{Reihen}
 
 \begin{subdefi}
-Sei \((a_n)_{n \ge 0}\) eine Folge reeller Zahlen. Sei weiters $ \displaystyle S_N = \sum_{n = 0}^{N}{a_n} $ die $N$-te Partialsumme, dann heißt die Folge \((S_N)_{N \ge 0}\) der Partialsummen eine unendliche Reihe.\\
-\[\text{Schreibweise: }\suminf{a_n}\]
+Sei \((a_n)_{n \ge 0}\) eine Folge reeller Zahlen. Sei weiters $ \displaystyle S_N = \sum_{n = 0}^{N}{a_n} $ die $N$-te Partialsumme, dann heißt die Folge \((S_N)_{N \ge 0}\) der Partialsummen eine unendliche Reihe.
+\[ \text{Schreibweise: }\suminf{a_n} \]
 Konvergiert die Folge \((S_N)\text{ mit }\liminf{S_N} = s \text{, dann heißt } \suminf{a_n} = s\) der Wert der Reihe. Man sagt: Die Reihe \(\suminf{a_n}\) konvergiert.
-\[\text{Schreibweise: } \suminf{a_n} < \infty\]
+\[ \text{Schreibweise: } \suminf{a_n} < \infty \]
 \end{subdefi}
 
 \begin{subbsp}\
 \begin{enumerate}
-\item Die geometrische Reihe. Sei \(\abs{a} < 1 \Rightarrow \suminf{a^n} = \frac{1}{1-a}\text{. Ist }\abs{a} \ge 1\text{, dann ist }\suminf{a^n}\) divergent.
-\begin{proof}$\begin{aligned}[t]
-&\IA {N=0}: \quad a^0 = \frac{(1-a)}{(1- a)} = 1\\
-&\IV \sum_{n = 0}^{N}{a^n} = \frac{1-a^{N+1}}{1-a}\\
-&\IS: {N \mapsto N+1}\\
+\item Die geometrische Reihe:
+\[\begin{aligned}[t]
+&\suminf{a^n} = \frac{1}{1-a} \text{ , wenn } \abs{a} < 1 \\
+&\suminf{a^n} \text{ ist divergent, wenn } \abs{a} \ge 1
+\end{aligned}\]
+
+\begin{proof}
+\[\begin{aligned}[t]
+&\IA[N=0] \quad a^0 = \frac{(1-a)}{(1- a)} = 1 \\
+&\IV \sum_{n = 0}^{N}{a^n} = \frac{1-a^{N+1}}{1-a} \\
+&\IS[N \mapsto N+1] \\
 &\sum_{n = 0}^{N+1}{a^n} = a^{N+1} + \sum_{n = 0}^{N}{a^n} \overset{IV}{=} a^{N+1} + \frac{1-a^{N+1}}{1-a} = \text{... selber} \\ %TODO
 &\text{Sei }S_N = \sum_{n=0}^{N}{a^n} = \frac{1 - a^{N+1}}{1- a} \\
 &\text{Sei }\abs{a} < 1\text{. Dann folgt }\liminf{a^N} = 0 \\
-&\Rightarrow \liminf{S_N} = \liminf{\frac{1-a^{N+1}}{1-a}} = \frac{1}{1-a}\\
+&\Rightarrow \liminf{S_N} = \liminf{\frac{1-a^{N+1}}{1-a}} = \frac{1}{1-a} \\
 &\text{Sei }a \ge 1 \Rightarrow \sum_{n=0}^{N}{a^n} \ge \sum_{n=0}^{N}{1} = N+1 \longrightarrow \inf \\
 &\text{Sei }a \le -1 \Rightarrow a = -b \text{ mit }b \ge 1 \Rightarrow \sum_{n=0}^{N}{a^n} \ge \sum_{n=0}^{N}{(-1)^nb^n} \text{ divergent}
-\end{aligned}$\\
+\end{aligned}\]
 \end{proof}
 
-\item Die harmonische Reihe: \(\sum_{n=1}^{\infty}{\frac{1}{n}} = +\infty\)
+\item Die harmonische Reihe:
+\[\sum_{n=1}^{\infty}{\frac{1}{n}} = +\infty\]
+
 \begin{proof}
-$\begin{aligned}[t]
+\[\begin{aligned}[t]
 &S_{2^N} = \sum_{n = 1}^{2^N}{\frac{1}{n}} =
 1 +\underbrace{\frac{1}{2}}_{=\frac{1}{2}} + \underbrace{\frac{1}{3} + \frac{1}{4}}_{=\frac{1}{2}} + \underbrace{\frac{1}{5} + \frac{1}{6} + \frac{1}{7} + \frac{1}{8}}_{=\frac{1}{2}} + \underbrace{\frac{1}{9} + ... + \frac{1}{16}}_{=\frac{1}{2}} + ... + \underbrace{\frac{1}{2^{N-1}+1}+ .... + \frac{1}{2^N}}_{=\frac{1}{2}} \\
 &\ge 1 + n \frac{1}{2} > \frac{n}{2} \longrightarrow +\infty
-\end{aligned}$
-\\\\
+\end{aligned}\]
+
 Würde \((S_N)_{N\ge1}\) konvergieren, dann auch die Teilfolge \((S_{2^N})_{N \ge 1}\), da diese dievergiert, divergiert auch \((S_N)_N\)\\
 \end{proof}
 
-\item $ \Suminf{\frac{1}{n(n+1)}}= 1 $
+\item
+\[ \Suminf{\frac{1}{n(n+1)}}= 1 \]
+
 \begin{proof}
-$\begin{aligned}[t]
+\[\begin{aligned}[t]
 &S_N = \sum_{n=1}^{N}{\frac{1}{n(n+1)}} = \sum_{n=1}^{N}{\frac{1}{n}} - \frac{1}{n+1} = \sum_{n=1}^{N}{\frac{1}{n}} - \sum_{n=1}^{N}{\frac{1}{n+1}}
 = 1 + \sum_{n=2}^{N}{\frac{1}{n}} - \sum_{n=2}^{N+1}{\frac{1}{n}} \\
 &= 1 + \sum_{n=2}^{N}{\frac{1}{n}} - \sum_{n=2}^{N}{\frac{1}{n}} + \frac{1}{N+1}
 = 1 + \frac{1}{N+1} \longrightarrow 1
-\end{aligned}$\\
+\end{aligned}\]
 \end{proof}
+
 \end{enumerate}
 \end{subbsp}
 
 \begin{subsatz}
 Seien \suminf{a_n} und \suminf{b_n} zwei konvergente Reihen und \(\lambda \in \R\),
-dann ist auch \(\suminf{\lambda a_n + b_n}\) konvergent und \( \suminf{\lambda a_n + b_n} = \lambda \suminf{a_n} + \suminf{b_n}\)
+dann ist auch \(\suminf{\lambda a_n + b_n}\) konvergent und \(\suminf{\lambda a_n + b_n} = \lambda \suminf{a_n} + \suminf{b_n}\)
 \begin{proof}
 folgt auf Grund der Rechenregeln für konvergente Folgen.
 \end{proof}
@@ -1029,7 +1042,8 @@ folgt auf Grund der Rechenregeln für konvergente Folgen.
 
 \begin{subsatz}[Cauchy-Kriterium für Reihen]
 Die Reihe \(\suminf[k]{a_k}\) ist konvergent, genau dann wenn gilt:
-\[\forall \epsilon > 0 \sp \exists N(\epsilon) \in \N \quad \forall n \ge m \ge N \qquad \abs{\sum_{k=m}^{n}{a_k}} < \epsilon \qquad (\star)\]
+% TODO Florian
+\[\forall \epsilon > 0 \spdot \exists N(\epsilon) \in \N \spdot \forall n \ge m \ge N \spcolon \abs{\sum_{k=m}^{n}{a_k}} < \epsilon \qquad (\star)\]
 \((\star)\) bedeutet die \((S_n)_n\) ist eine Cauchy-Folge \(\Leftrightarrow (S_n)_n\) ist konvergent
 \begin{proof}
 \(S_n - S_m = \sum_{k=0}^{n}{a_k} - \sum_{k=0}^{m}{a_k} = \sum_{k=m}^{n}{a_k}\).\\
@@ -1039,7 +1053,10 @@ Die Reihe \(\suminf[k]{a_k}\) ist konvergent, genau dann wenn gilt:
 \begin{subkorr}
 Ist \suminf[k]{a_k} konvergent \(\Rightarrow \liminf[k]{a_k} = 0\).
 \begin{proof}
-\(a_n = \sum_{k = m}^{n}{a_k} \text{. Da } \suminf[k]{a_k} < \infty \overset{\text{Cauchy-Kriterium}}{\Rightarrow} \forall \epsilon > 0 \sp \exists N \in \N \quad \forall n \ge N \abs{a_N} = \abs{ \sum_{k = m}^{n}{a_k}} < \epsilon  \Rightarrow \liminf{a_n} = 0\)\\
+\[\begin{aligned}[t]
+&a_n = \sum_{k = m}^{n}{a_k} \\
+&\text{Da } \suminf[k]{a_k} < \infty \overset{\text{Cauchy-Kriterium}}{\Rightarrow} \forall \epsilon > 0 \sp \exists N \in \N \quad \forall n \ge N \abs{a_N} = \abs{ \sum_{k = m}^{n}{a_k}} < \epsilon \Rightarrow \liminf{a_n} = 0\\
+\end{aligned}\]
 \end{proof}
 \end{subkorr}
 
@@ -1054,10 +1071,11 @@ Die Reihe \suminf[k]{a_k} heißt absolut konvergent, wenn die Reihe \suminf[k]{\
 \begin{subsatz}
 Jede absolut konvergente Reihe ist auch konvergent.
 \begin{proof}
-\begin{math}
-\text{Sei }\suminf[k]{\abs{a_k}} < \infty  \overset{\text{Cauchy-Kriterium}}{\Rightarrow} \forall \epsilon > 0 \sp \exists N \in \N \sp \forall n \ge m \ge N \sp \abs{\sum_{k=m}^{n}{\abs{a_k}}} < \epsilon \overset{\text{Dreiecksungleichung}}{\Rightarrow} \abs{\sum_{k=m}^{n}{a_k}} \le \abs{\sum_{k=m}^{n}{\abs{a_k}}} < \epsilon \sp gilt \sp \forall n \ge m \ge N
-\overset{\text{Cauchy-Kriterium}}{\Rightarrow} \suminf[k]{a_k}\text{ ist konvergent.}
-\end{math}\\
+\[\begin{aligned}[t]
+&\text{Sei }\suminf[k]{\abs{a_k}} < \infty  \overset{\text{Cauchy-Kriterium}}{\Rightarrow} \forall \epsilon > 0 \sp \exists N \in \N \sp \forall n \ge m \ge N \sp \abs{\sum_{k=m}^{n}{\abs{a_k}}} < \epsilon \\
+&\overset{\text{Dreiecksungleichung}}{\Rightarrow} \abs{\sum_{k=m}^{n}{a_k}} \le \abs{\sum_{k=m}^{n}{\abs{a_k}}} < \epsilon \sp gilt \sp \forall n \ge m \ge N \\
+&\overset{\text{Cauchy-Kriterium}}{\Rightarrow} \suminf[k]{a_k}\text{ ist konvergent.}
+\end{aligned}\]
 \end{proof}
 \end{subsatz}
 
@@ -1066,28 +1084,38 @@ Die Umkehrung des Satzes gilt nicht. zB kann man zeigen, dass die Reihe \(\sumin
 \end{subbem}
 
 \begin{subsatz}[Majoranten-Kriterium]
-Sei \suminf[k]{b_k} konvergent mit \(b_k \ge 0 \forall k \ge N_0\).
-Sei \((a_k)_{k=0}^{\infty}\) eine Folge mit \(\abs{a_k} \le b_k  \forall k \ge N_0 \Rightarrow \suminf[k]{a_k}\) ist absolut konvergent.
+\[\begin{aligned}[t]
+&\text{Sei } \suminf[k]{b_k} \text{ konvergent mit } b_k \ge 0 , \forall k \ge N_0 \\
+&\text{Sei } (a_k)_{k=0}^{\infty} \text{ eine Folge mit } \abs{a_k} \le b_k , \forall k \ge N_0 \\
+&\Rightarrow \suminf[k]{a_k} \text{ ist absolut konvergent}
+\end{aligned}\]
+
 \begin{proof}
-\begin{math}
-\text{Sei }\suminf[k]{b_k} < \infty \text{ und } b_k > 0 \overset{\Rightarrow}{\text{Cauchy-Kriterium}} \forall \epsilon > 0 \sp \exists N \in \N \quad \forall n \ge m \ge N \quad \abs{\sum{k=m}{n}{b_k}} < \epsilon \overset{\Rightarrow}{\abs{a_k} \le b_k} \abs{\sum{k=m}{n}{\abs{a_k}}} \le \abs{\sum{k=m}{n}{b_k}} < \epsilon \forall n \ge m \ge N
-\overset{\Rightarrow}{\text{Cauchy-Kriterium}} \suminf[k]{\abs{a_k}} \text{ ist konvergent. }\Rightarrow \suminf[k]{a_k}\text{ ist absolut konvergent.}
-\end{math}
+\[\begin{aligned}[t]
+&\text{Sei } \suminf[k]{b_k} < \infty \text{ und } b_k > 0 \\
+&\overset{\text{Cauchy-Kriterium}}{\Rightarrow} \forall \epsilon > 0 \sp \exists N \in \N \quad \forall n \ge m \ge N \quad \abs{\sum{k=m}{n}{b_k}} < \epsilon \\
+&\overset{\abs{a_k} \le b_k}{\Rightarrow} \abs{\sum{k=m}{n}{\abs{a_k}}} \le \abs{\sum{k=m}{n}{b_k}} < \epsilon \forall n \ge m \ge N \\
+&\overset{\text{Cauchy-Kriterium}}{\Rightarrow} \suminf[k]{\abs{a_k}} \text{ ist konvergent} \\
+&\Rightarrow \suminf[k]{a_k}\text{ ist absolut konvergent.}
+\end{aligned}\]
 \end{proof}
 \end{subsatz}
 
 \begin{subkorr}[Minoranten-Kriterium]
-Sei \suminf[k]{b_k} divergent mit $b_k \ge 0 \forall k \ge N_0$.
-und $(a_k)_{k=0}^{\infty}$ eine Folge mit $\abs{a_k} \ge b_k  \forall k \ge N_0
-\Rightarrow \suminf[k]{a_k}$ ist auch divergent.
+\[\begin{aligned}[t]
+&\text{Sei } \suminf[k]{b_k} \text{ divergent mit } b_k \ge 0 , \forall k \ge N_0 \\
+&\text{Sei } (a_k)_{k=0}^{\infty} \text{eine Folge mit } \abs{a_k} \ge b_k , \forall k \ge N_0 \\
+&\Rightarrow \suminf[k]{a_k} \text{ ist auch divergent}
+\end{aligned}\]
+
 \begin{proof}
 Wäre \(\suminf[k]{a_k}\) konvergent, dann wäre nach dem Majoranten-Kriterium \(\suminf[k]{b_k}\) konvergent, da \(\abs{b_k} \le a_k\). \WSP
 \end{proof}
 \end{subkorr}
 
 \begin{subsatz}[Quotienten-Kriterium]
-Sei \suminf{a_n} eine Reihe mit \(a_n \ne 0 \forall n \ge n_0\)
-Existiert eine reelle Zahl \(q \text{ mit } 0 < q < 1 \text{ sodass }\abs{\frac{a_{n+1}}{a_n}} \le q < 1 \forall n \ge n_0
+Sei \suminf{a_n} eine Reihe mit \(a_n \ne 0 , \forall n \ge n_0\) \\
+Existiert eine reelle Zahl \(q \text{ mit } 0 < q < 1 \text{ ,so dass } \abs{\frac{a_{n+1}}{a_n}} \le q < 1 , \forall n \ge n_0 \\
 \Rightarrow \suminf{a_n}\) ist absolut konvergent.
 \begin{proof}
 \begin{math}
@@ -1671,7 +1699,7 @@ Diese Funktionen sind wieder stetig und streng monoton.
 \end{defi}
 
 \newpage
-\section{Differentialrechnung} 
+\section{Differentialrechnung}
 
 \begin{defi}
 Eien Funktion $f : D \to \R$ heißt differenzierbar in $x_0 \in D$, falls $\limnull[h]{\frac{f(x + h) - f(x_0)}{h}} = f'(x_0)$
@@ -1816,7 +1844,7 @@ $f$ heißt stetig differenzierbar, wenn $f$ differenzierbar ist und die Ableitun
 
 \begin{satz}[Der Satz von Rolle]
 Sei $f : [a,b] \to \R $ stetig und auf $(a,b)$ differenzierbar. Weiters sei $f(a) = f(b) = 0$. Dann folgt es gibt ein $x_0 \in (a,b)$ mit $f'(x) = 0$
-%grafik: satz von Rolle 
+%grafik: satz von Rolle
 \begin{proof}
 Ist $f(x) = 0 \sp \forall x \in (a,b) \sp \Rightarrow \sp f'(x) = 0 \sp \forall x \in (a,b)$. \\
 Wir können also annehmen: Es gibt ein $ x \in (a,b)$ mit $f(x) > 0$. (Wenn $f(x) < 0$ betrachte die Funktion $-f$). Da $f$ auf $[a,b]$ stetig ist, folgt aus dem Satz vom Maximum, dass $f$ an einer Stelle $x_0 \in (a,b) $ ihr Maximum annimmt.\\
@@ -1890,7 +1918,7 @@ Sei $f : [a,b] \to \R $ stetig und auf $(a,b)$ differenzierbar.
 \begin{enumerate}
 \item Haben wir im Beweis von Satz von Rolle gezeigt.
 \item Wir zeigen nur für Maximum, fürs Minimum betrachte $-f$\\
-Sei $f'(x_0) = 0$ und $f''(x_0) < 0$. Da $f''(x_0) = \limA{\frac{f'(x) - f'(x_0)}{x - x_0}} < 0 \Rightarrow \sp \exists \epsilon < 0 \sp \forall x \sp \abs{x_0 - x} < \epsilon \text{ für } x_0 \ne x \text{ mit } \frac{f'(x) - f'(x_0)}{x - x_0} < 0$ 
+Sei $f'(x_0) = 0$ und $f''(x_0) < 0$. Da $f''(x_0) = \limA{\frac{f'(x) - f'(x_0)}{x - x_0}} < 0 \Rightarrow \sp \exists \epsilon < 0 \sp \forall x \sp \abs{x_0 - x} < \epsilon \text{ für } x_0 \ne x \text{ mit } \frac{f'(x) - f'(x_0)}{x - x_0} < 0$
 \begin{enumerate}
 \item[Fall 1] $x < x_0 \Rightarrow f'(x) > f'(x_0) = 0 \Rightarrow $ streng monoton wachsend auf $(x_0 - \epsilon, x_0)$
 \item[Fall 2] $x > x_0 \Rightarrow f'(x) < f'(x_0) = 0  \Rightarrow $ streng monoton fallend auf $(x_0, x_0 + \epsilon)$
@@ -1901,13 +1929,13 @@ $\Rightarrow f$ hat in $x_0$ ein lokales Maximum.
 \end{satz}
 
 \begin{bem}
-Die Umkehrung des Satzes gilt nicht. 
+Die Umkehrung des Satzes gilt nicht.
 zB: $f(x) = x^4$ hat in $x = 0$ ein Minimum. Aber $f'(0) = f''(0) = 0$. Für $f(x) = x^3$ ist $f'(0) = 0$ aber $ x = 0$ ist kein Extremum.\\
 \end{bem}
 
 \begin{satz}[Regel von de l'Hospital]
 Sei $-\infty \le a < b \le \infty$. Sei $f : (a,b) \to \R $ differenzierbar und es existiert $\limpos[x]{a}{\frac{f'(x)}{g'(x)}} = c \in \R$.
-Dann gilt: 
+Dann gilt:
 \begin{enumerate}
 \item Ist $\limpos[x]{a}{f'(x)} = \limpos[x]{a}{g'(x)} = 0 \Rightarrow g(x) \ne 0 \text{ und } \limpos[x]{a}{\frac{f(x)}{g(x)}} = c$
 \item Ist $\limpos[x]{a}{f'(x)} = \limpos[x]{a}{g'(x)} = \pm \infty \Rightarrow g(x) \ne 0 \text{ und } \limpos[x]{a}{\frac{f(x)}{g(x)}} = c$
@@ -1917,7 +1945,7 @@ Ebenso für $\limneg[x]{b}{\frac{f'(x)}{g'(x)}} = c$
 1. Aus dem verallgemeinerten Mittelwertsatz folgt zu jedem $x \in (a,b)$ gibt es ein $t_x \in (a,x)$ mit $\frac{f'(t_x)}{g'(t_x)} = \frac{f(x) - f(a)}{g(x) - g(a)} = \frac{f(x)}{g(x)}$\\
 Konvergiert $x \to a \Rightarrow  t_x \to a$
 $\Rightarrow \limpos[x]{a}{\frac{f(x)}{g(x)}} = \limpos[t_x]{a}{\frac{f'(t_x)}{g'(t_x)}}$
-2. analog zu 1. 
+2. analog zu 1.
 \end{proof}
 \end{satz}
 
@@ -1948,7 +1976,7 @@ Aus 3. und 4. folgt: Ist $ f(x) \le 0 \sp \fa x \in [a,b] \sp \Rightarrow \sp \i
 \begin{defi}
 Eine Treppenfunktion $\phi : [a,b] \to \R$ ist folgende Funktion: \\
 Es gibt eine Unterteilung des Intervalls $[a,b]$, mit $a = t_0 < \dots < t_n = b$ und Konstanten $ z_1, \dots z_n \in \R$, sodass $\phi(x) = c_k \sp \fa x\in (t_{k-1},t_k) $ für $k = 1,\dots, n$. Die Werte $\phi(t_k) $ für $k = 0,\dots, n$ sind beliebig.
-%Grafik beliebigeTrepenfunktion 
+%Grafik beliebigeTrepenfunktion
 \end{defi}
 
 \begin{defi}[Integral für Treppenfunktion]
@@ -1971,7 +1999,7 @@ Erweiterung des Integrals auf stetige und stückweise stetige Funktionen.
 \end{bem}
 
 \begin{satz}[Gleichmäßige Stetigkeit]
-Sei $[a,b]$ ein abgeschlossenenes Intervall und $ f: [a,b] \to \R $ eine stetige Funktion. Dann gilt: 
+Sei $[a,b]$ ein abgeschlossenenes Intervall und $ f: [a,b] \to \R $ eine stetige Funktion. Dann gilt:
 \[\forall \epsilon > 0 \exists \delta > 0 \sp: \sp \forall x, x' \in [a,b] \text{ mit } \abs{x- x'} < \delta \text{ folgt } \abs{f(x) - f(x')} < \epsilon\]
 \begin{proof}
 Angenommen $f$ ist nicht gleichmäßig stetig. $\Rightarrow \exists \epsilon > 0 \sp \forall \delta > 0 \sp \exists x,x' \in [a,b] \text{ mit } \abs{x- x'} < \delta \text{ aber } \abs{f(x) - f(x')} \ge \epsilon$. Speziell gibt es ein $\epsilon > 0$ derart, dass so zu jedem $n \ge 1 \sp x_n, x_n' \in [a,b] $ gibt mit $\abs{x_n - x_n'} < \frac{1}{n}$, aber $\abs{f(x_n) - f(x_n')} \ge \epsilon$.\\
@@ -2000,7 +2028,7 @@ eine Funktion $f: [a,b] \to \R$ heißt stückweise stetig, wenn es eine Untertei
 \end{bsp}
 
 \begin{prop}[wichtig]
-Sei $f : [a,b] \to \R$ stückweise stetig und $\epsilon > 0$. Dann gibt es Treppenfunktionen $\phi, \psi : [a,b] \to \R$ mit 
+Sei $f : [a,b] \to \R$ stückweise stetig und $\epsilon > 0$. Dann gibt es Treppenfunktionen $\phi, \psi : [a,b] \to \R$ mit
 \begin{enumerate}
 \item $\phi(x) \le f(x) \le \psi(x) \quad \forall x \in [a,b]$
 \item $\abs{\phi(x) - \psi(x)} < \epsilon \quad \forall x \in [a,b]$
@@ -2053,7 +2081,7 @@ $\Rightarrow 0 \le \OI{f} - \UI{f} \le \frac{1}{n} \quad \forall n \ge 1 \Righta
 \end{enumerate}
 \end{proof}
 \end{satz}
- 
+
 \begin{defi}
 Sei $f: [a,b] \to \R$ stückweise stetig. Dann heißt \[\int_{a}^{b}{f} = \intAB{f(x)} = \OI{f} = \UI{f}\] das bestimmte Integral von $f$.
 \end{defi}
@@ -2108,7 +2136,7 @@ Man schreibt oft. $F(x) = \int{f(t)\der t} + c$
 \end{bem}
 
 \begin{prop}[Hauptsatz der Differential- und Integralrechnung - Teil I]
-Sei $f: [a,b] \to \R$ stetig. Definiere $F: [a,b] \to \R$ folgendermaßen 
+Sei $f: [a,b] \to \R$ stetig. Definiere $F: [a,b] \to \R$ folgendermaßen
 \[F(x) = \int_{a}^{x}{f(t)\der t}\]
 Dann ist $F$ eine Stammfunktion von $f$.
 \begin{proof}
@@ -2121,7 +2149,7 @@ $F(x+h_n) - F(x) = \int_{a}^{x+h_n}{f(t)\der t} - \int_{a}^{x}{f(t)\der t} = \in
 Nach dem Mittelwertsatz der Integralrechnung exisitiert ein $x_n \in [x, x+ h_n]$ mit $\int_{x}^{x+h_n}{f(t)\der t} = h_n f(x_n)$.
 d.h. $\frac{F(x+h_n) - F(x)}{h_n} = f(x_n)$.\\
 Da $ \liminf{h_n} = 0 \Rightarrow \liminf{x_n} = x.$ Da $f$ stetig ist, folgt $\liminf{f(x_n)} = f(x)$. d.h. $\liminf{\frac{F(x+h_n) - F(x)}{h_n}} = \liminf{f(x_n)} = f(x).$\\
-Also ist $F$ differenzierbar und $F'(x) = f(x) \sp \forall x \in [a,b]$ 
+Also ist $F$ differenzierbar und $F'(x) = f(x) \sp \forall x \in [a,b]$
 \end{proof}
 \end{prop}
 
@@ -2171,7 +2199,7 @@ $\overset{\text{Hauptsatz}}{\Rightarrow} \intAB[t]{f(\phi(t))\phi'(t)} = \intAB[
 \end{satz}
 
 \begin{bem}
-Schreibt man symbolisch $\der \phi(t) = \phi'(t)\der t \Rightarrow \int_{a}^{b}{f(\phi(t))\phi'(t) \der t} = \integral{\phi(a)}{\phi(b)}{f(x)}$ 
+Schreibt man symbolisch $\der \phi(t) = \phi'(t)\der t \Rightarrow \int_{a}^{b}{f(\phi(t))\phi'(t) \der t} = \integral{\phi(a)}{\phi(b)}{f(x)}$
 \end{bem}
 
 \begin{bsp}


### PR DESCRIPTION
Hab das Kapitel Reihen schöner formatiert. Außerdem 2 neue commands \spdot (Punkt mit spaces) und \spcolon (Doppelpunkt mit spaces) hinzugefügt, damit man ∀ und ∃ Formeln besser lesen kann.